### PR TITLE
Rename PCF to CF

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
     - image: circleci/golang:1.12
-    working_directory: /go/src/github.com/hashicorp/vault-plugin-auth-pcf
+    working_directory: /go/src/github.com/hashicorp/vault-plugin-auth-cf
     steps:
     - checkout
     - run:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TOOL?=vault-plugin-auth-pcf
+TOOL?=vault-plugin-auth-cf
 TEST?=$$(go list ./... | grep -v /vendor/ | grep -v teamcity)
 VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr
 EXTERNAL_TOOLS=\

--- a/README.md
+++ b/README.md
@@ -278,33 +278,33 @@ openssl s_client -showcerts -connect pcf.lagunaniguel.cf-app.com:443
 
 You'll see a certificate outputted as part of the response, which should be broken
 out into a separate well-formatted file like the `ca.crt` above, and used for the
-`pcf_api_trusted_certificates` field.
+`cf_api_trusted_certificates` field.
 
 ## Downloading the Plugin
 
-- `$ git clone git@github.com:hashicorp/vault-plugin-auth-pcf.git`
-- `$ cd vault-plugin-auth-pcf`
-- `$ PCF_HOME=$(pwd)`
+- `$ git clone git@github.com:hashicorp/vault-plugin-auth-cf.git`
+- `$ cd vault-plugin-auth-cf`
+- `$ CF_HOME=$(pwd)`
 
 ## Sample Usage
 
 Please note that this example uses `generate-signature`, a tool installed through `$ make tools`.
 
-First, enable the PCF auth engine.
+First, enable the CF auth engine.
 ```
-$ vault auth enable pcf
+$ vault auth enable cf
 ```
 
 Next, configure the plugin. In the `config` call below, `certificates` is intended to be the instance
 identity CA certificate you pulled above.
 
 ```
-$ vault write auth/pcf/config \
+$ vault write auth/cf/config \
       identity_ca_certificates=@ca.crt \
-      pcf_api_addr=https://api.sys.lagunaniguel.cf-app.com \
-      pcf_username=vault \
-      pcf_password=pa55word \
-      pcf_api_trusted_certificates=@pcfapi.crt
+      cf_api_addr=https://api.sys.lagunaniguel.cf-app.com \
+      cf_username=vault \
+      cf_password=pa55word \
+      cf_api_trusted_certificates=@cfapi.crt
 ```
 
 Then, add a role that will be used to grant specific Vault policies to those logging in with it. When a constraint like
@@ -325,7 +325,7 @@ $ openssl crl2pkcs7 -nocrl -certfile instance.crt | openssl pkcs7 -print_certs -
 Also, by default, the IP address on the certificate presented at login must match that of the caller. However, if
 your callers tend to be proxied, this may not work for you. If that's the case, set `disable_ip_matching` to true.
 ```
-$ vault write auth/pcf/roles/test-role \
+$ vault write auth/cf/roles/test-role \
     bound_application_ids=2d3e834a-3a25-4591-974c-fa5626d5d0a1 \
     bound_space_ids=3d2eba6b-ef19-44d5-91dd-1975b0db5cc9 \
     bound_organization_ids=34a878d0-c2f9-4521-ba73-a9f664e82c7bf \
@@ -335,14 +335,14 @@ $ vault write auth/pcf/roles/test-role \
 Logging in is intended to be performed using your `CF_INSTANCE_CERT` and `CF_INSTANCE_KEY`. This is an example of how
 it can be done.
 ```
-$ export CF_INSTANCE_CERT=$PCF_HOME/testdata/fake-certificates/instance.crt
-$ export CF_INSTANCE_KEY=$PCF_HOME/testdata/fake-certificates/instance.key
-$ vault login -method=pcf role=test-role
+$ export CF_INSTANCE_CERT=$CF_HOME/testdata/fake-certificates/instance.crt
+$ export CF_INSTANCE_KEY=$CF_HOME/testdata/fake-certificates/instance.key
+$ vault login -method=cf role=test-role
 ```
 
 ### Updating the CA Certificate
 
-In PCF, most CA certificates expire after 4 years. However, it's possible to configure your own CA certificate for the
+In Cloud Foundry, most CA certificates expire after 4 years. However, it's possible to configure your own CA certificate for the
 instance identity service, and its expiration date could vary. Either way, sometimes CA certificates expire and it may
 be necessary to have multiple configured so the beginning date of once commences when another expires.
 
@@ -350,7 +350,7 @@ To configure multiple certificates, simply update the config to include the curr
 ```
 $ CURRENT=$(cat /path/to/current-ca.crt)
 $ FUTURE=$(cat /path/to/future-ca.crt)
-$ vault write auth/vault-plugin-auth-pcf/config certificates="$CURRENT,$FUTURE"
+$ vault write auth/vault-plugin-auth-cf/config certificates="$CURRENT,$FUTURE"
 ```
 
 All other configured values will remain untouched; however, the previous value for `certificates` will be overwritten
@@ -362,20 +362,20 @@ login will succeed.
 
 ## Troubleshooting
 
-### Obtaining a Certificate Error from the PCF API
+### Obtaining a Certificate Error from the CF API
 
 When configuring this plugin, you may encounter an error like:
 ```
-Error writing data to auth/pcf/config: Error making API request.
+Error writing data to auth/cf/config: Error making API request.
 
-URL: PUT http://127.0.0.1:8200/v1/auth/pcf/config
+URL: PUT http://127.0.0.1:8200/v1/auth/cf/config
 Code: 500. Errors:
 
 * 1 error occurred:
 	* unable to establish an initial connection to the PCF API: Could not get api /v2/info: Get https://api.sys.lagunaniguel.cf-app.com/v2/info: x509: certificate signed by unknown authority
 ```
 
-To resolve this error, review instructions above regarding setting the `pcf_api_trusted_certificates` field.
+To resolve this error, review instructions above regarding setting the `cf_api_trusted_certificates` field.
 
 ### verify-certs
 
@@ -388,7 +388,7 @@ verify-certs -ca-cert=local/path/to/ca.crt -instance-cert=local/path/to/instance
 ```
 The `ca-cert` should be the cert that was used to issue the given client certificate.
 
-The `instance-cert` given should be the value for the `CF_INSTANCE_CERT` variable in the PCF environment you're
+The `instance-cert` given should be the value for the `CF_INSTANCE_CERT` variable in the Cloud Foundry environment you're
 using, and the `instance-key` should be the value for the `CF_INSTANCE_KEY`.
 
 The tool does take the _local path to_ these certificates, so you'll need to gather them and place them on your
@@ -396,7 +396,7 @@ local machine to verify they all will work together.
 
 ### generate-signature
 
-This tool, installed by `make tools`, is for generating a valid signature to be used for signing into Vault via PCF. 
+This tool, installed by `make tools`, is for generating a valid signature to be used for signing into Vault via Cloud Foundry. 
 
 It can be used as a standalone tool for generating a signature like so:
 ```
@@ -414,25 +414,25 @@ export CF_INSTANCE_KEY=path/to/instance.key
 export SIGNING_TIME=$(date -u)
 export ROLE='test-role'
 
-vault write auth/vault-plugin-auth-pcf/login \
+vault write auth/vault-plugin-auth-cf/login \
     role=$ROLE \
     certificate=$CF_INSTANCE_CERT \
     signing-time=SIGNING_TIME \
     signature=$(generate-signature)
 ```
-If the tool is being run in a PCF environment already containing the `CF_INSTANCE_CERT` and `CF_INSTANCE_KEY`, those
+If the tool is being run in a Cloud Foundry environment already containing the `CF_INSTANCE_CERT` and `CF_INSTANCE_KEY`, those
 variables obviously won't need to be manually set before the tool is used and can just be pulled as they are.
 
 ## Developing
 
-### mock-pcf-server
+### mock-cf-server
 
-This tool, installed by `make tools`, is for use in development. It lets you run a mocked PCF server for use in local 
-testing, with output that can be used as the `pcf_api_addr`, `pcf_username`, and `pcf_password` in your config.
+This tool, installed by `make tools`, is for use in development. It lets you run a mocked Cloud Foundry server for use in local 
+testing, with output that can be used as the `cf_api_addr`, `cf_username`, and `cf_password` in your config.
 
 Example use:
 ```
-$ mock-pcf-server
+$ mock-cf-server
 running at http://127.0.0.1:33671
 username is username
 password is password
@@ -520,7 +520,7 @@ This signature should be placed in the `signature` field of login requests.
 
 If you implement the algorithm above and still encounter errors logging in,
 it may help to generate test certificates using the `make-test-certs` tool.
-These certificates are accurate enough mocks of real PCF certificates, and 
+These certificates are accurate enough mocks of real Cloud Foundry certificates, and 
 are used for testing. Using this tool to generate your test certificates will
 rule out any error with the certificates you may have created yourself.
 
@@ -537,7 +537,7 @@ path to key to use as CF_INSTANCE_KEY: /tmp/5c08f79d-b2a5-c211-2862-00fe0a3b647d
 - [Java](https://github.com/tyrannosaurus-becks/vault-tools-auth-pcf)
 - Python:
 ```
-## PCF signature creation example in Python using the [Cryptography](https://cryptography.io) library
+## CF signature creation example in Python using the [Cryptography](https://cryptography.io) library
 import base64
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
@@ -576,25 +576,25 @@ make dev
 make tools
 
 # In one shell window, run Vault with the plugin available in the catalog.
-vault server -dev -dev-root-token-id=root -dev-plugin-dir=$PCF_HOME/bin -log-level=debug
+vault server -dev -dev-root-token-id=root -dev-plugin-dir=$CF_HOME/bin -log-level=debug
 
-# In another shell window, run a mock of the PCF API so the plugin's client calls won't fail.
-mock-pcf-server
+# In another shell window, run a mock of the CF API so the plugin's client calls won't fail.
+mock-cf-server
 
 # In another shell window, execute the following commands to exercise each endpoint.
 export VAULT_ADDR=http://localhost:8200
 export VAULT_TOKEN=root
-export MOCK_PCF_SERVER_ADDR='something' # ex. http://127.0.0.1:32937
+export MOCK_CF_SERVER_ADDR='something' # ex. http://127.0.0.1:32937
 
-vault auth enable vault-plugin-auth-pcf
+vault auth enable vault-plugin-auth-cf
 
-vault write auth/vault-plugin-auth-pcf/config \
-    certificates=@$PCF_HOME/testdata/fake-certificates/ca.crt \
-    pcf_api_addr=$MOCK_PCF_SERVER_ADDR \
-    pcf_username=username \
-    pcf_password=password
+vault write auth/vault-plugin-auth-cf/config \
+    certificates=@$CF_HOME/testdata/fake-certificates/ca.crt \
+    cf_api_addr=$MOCK_CF_SERVER_ADDR \
+    cf_username=username \
+    cf_password=password
     
-vault write auth/vault-plugin-auth-pcf/roles/test-role \
+vault write auth/vault-plugin-auth-cf/roles/test-role \
     bound_application_ids=2d3e834a-3a25-4591-974c-fa5626d5d0a1 \
     bound_space_ids=3d2eba6b-ef19-44d5-91dd-1975b0db5cc9 \
     bound_organization_ids=34a878d0-c2f9-4521-ba73-a9f664e82c7bf \
@@ -605,11 +605,11 @@ vault write auth/vault-plugin-auth-pcf/roles/test-role \
     max_ttl=86400s \
     period=86400s
     
-export CF_INSTANCE_CERT=$PCF_HOME/testdata/fake-certificates/instance.crt
-export CF_INSTANCE_KEY=$PCF_HOME/testdata/fake-certificates/instance.key
+export CF_INSTANCE_CERT=$CF_HOME/testdata/fake-certificates/instance.crt
+export CF_INSTANCE_KEY=$CF_HOME/testdata/fake-certificates/instance.key
 export SIGNING_TIME=$(date -u)
 export ROLE='test-role'
-vault write auth/vault-plugin-auth-pcf/login \
+vault write auth/vault-plugin-auth-cf/login \
     role=$ROLE \
     certificate=@$CF_INSTANCE_CERT \
     signing_time="$SIGNING_TIME" \
@@ -617,7 +617,7 @@ vault write auth/vault-plugin-auth-pcf/login \
     
 vault token renew <token>
 
-CURRENT=$(cat $PCF_HOME/testdata/fake-certificates/ca.crt)
-FUTURE=$(cat $PCF_HOME/testdata/fake-certificates/ca.crt)
-vault write auth/vault-plugin-auth-pcf/config certificates="$CURRENT,$FUTURE"
+CURRENT=$(cat $CF_HOME/testdata/fake-certificates/ca.crt)
+FUTURE=$(cat $CF_HOME/testdata/fake-certificates/ca.crt)
+vault write auth/vault-plugin-auth-cf/config certificates="$CURRENT,$FUTURE"
 ```

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ URL: PUT http://127.0.0.1:8200/v1/auth/cf/config
 Code: 500. Errors:
 
 * 1 error occurred:
-	* unable to establish an initial connection to the PCF API: Could not get api /v2/info: Get https://api.sys.lagunaniguel.cf-app.com/v2/info: x509: certificate signed by unknown authority
+	* unable to establish an initial connection to the CF API: Could not get api /v2/info: Get https://api.sys.lagunaniguel.cf-app.com/v2/info: x509: certificate signed by unknown authority
 ```
 
 To resolve this error, review instructions above regarding setting the `cf_api_trusted_certificates` field.

--- a/backend.go
+++ b/backend.go
@@ -1,4 +1,4 @@
-package pcf
+package cf
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 
 const (
 	// These env vars are used frequently to pull the client certificate and private key
-	// from PCF containers; thus are placed here for ease of discovery and use from
+	// from CF containers; thus are placed here for ease of discovery and use from
 	// outside packages.
 	EnvVarInstanceCertificate = "CF_INSTANCE_CERT"
 	EnvVarInstanceKey         = "CF_INSTANCE_KEY"
@@ -43,7 +43,7 @@ type backend struct {
 }
 
 const backendHelp = `
-The PCF auth backend supports logging in using PCF's identity service.
+The CF auth backend supports logging in using CF's identity service.
 Once a CA certificate is configured, and Vault is configured to consume
-PCF's API, PCF's instance identity credentials can be used to authenticate.'
+CF's API, CF's instance identity credentials can be used to authenticate.'
 `

--- a/backend_test.go
+++ b/backend_test.go
@@ -1,4 +1,4 @@
-package pcf
+package cf
 
 import (
 	"context"
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault-plugin-auth-pcf/models"
-	"github.com/hashicorp/vault-plugin-auth-pcf/signatures"
-	"github.com/hashicorp/vault-plugin-auth-pcf/testing/certificates"
-	"github.com/hashicorp/vault-plugin-auth-pcf/testing/pcf"
+	"github.com/hashicorp/vault-plugin-auth-cf/models"
+	"github.com/hashicorp/vault-plugin-auth-cf/signatures"
+	"github.com/hashicorp/vault-plugin-auth-cf/testing/certificates"
+	"github.com/hashicorp/vault-plugin-auth-cf/testing/cf"
 	"github.com/hashicorp/vault/sdk/helper/parseutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -23,7 +23,7 @@ func TestBackend(t *testing.T) {
 	ctx := context.Background()
 	storage := &logical.InmemStorage{}
 
-	testCerts, err := certificates.Generate(pcf.FoundServiceGUID, pcf.FoundOrgGUID, pcf.FoundSpaceGUID, pcf.FoundAppGUID, "10.255.181.105")
+	testCerts, err := certificates.Generate(cf.FoundServiceGUID, cf.FoundOrgGUID, cf.FoundSpaceGUID, cf.FoundAppGUID, "10.255.181.105")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,14 +38,14 @@ func TestBackend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pcfServer := pcf.MockServer(false)
-	defer pcfServer.Close()
+	cfServer := cf.MockServer(false)
+	defer cfServer.Close()
 
 	testConf := &models.Configuration{
 		IdentityCACertificates: []string{testCerts.CACertificate, string(invalidCaCertBytes)},
-		PCFAPIAddr:             pcfServer.URL,
-		PCFUsername:            pcf.AuthUsername,
-		PCFPassword:            pcf.AuthPassword,
+		CFAPIAddr:              cfServer.URL,
+		CFUsername:             cf.AuthUsername,
+		CFPassword:             cf.AuthPassword,
 		LoginMaxSecNotBefore:   5,
 		LoginMaxSecNotAfter:    1,
 	}
@@ -72,10 +72,10 @@ func TestBackend(t *testing.T) {
 		Backend:  backend,
 		TestConf: testConf,
 		TestRole: &models.RoleEntry{
-			BoundAppIDs:      []string{pcf.FoundAppGUID},
-			BoundSpaceIDs:    []string{pcf.FoundSpaceGUID},
-			BoundOrgIDs:      []string{pcf.FoundOrgGUID},
-			BoundInstanceIDs: []string{pcf.FoundServiceGUID},
+			BoundAppIDs:      []string{cf.FoundAppGUID},
+			BoundSpaceIDs:    []string{cf.FoundSpaceGUID},
+			BoundOrgIDs:      []string{cf.FoundOrgGUID},
+			BoundInstanceIDs: []string{cf.FoundServiceGUID},
 			BoundCIDRs:       parsedCIDRs,
 			Policies:         []string{"default", "foo"},
 			TTL:              60,
@@ -119,9 +119,9 @@ func (e *Env) CreateConfig(t *testing.T) {
 		Storage:   e.Storage,
 		Data: map[string]interface{}{
 			"identity_ca_certificates":     e.TestConf.IdentityCACertificates,
-			"pcf_api_addr":                 e.TestConf.PCFAPIAddr,
-			"pcf_username":                 e.TestConf.PCFUsername,
-			"pcf_password":                 e.TestConf.PCFPassword,
+			"cf_api_addr":                  e.TestConf.CFAPIAddr,
+			"cf_username":                  e.TestConf.CFUsername,
+			"cf_password":                  e.TestConf.CFPassword,
 			"login_max_seconds_not_before": 12,
 			"login_max_seconds_not_after":  13,
 		},
@@ -153,14 +153,14 @@ func (e *Env) ReadConfig(t *testing.T) {
 			t.Fatalf("expected %q but received %q", e.TestConf.IdentityCACertificates[i], caCertRaw)
 		}
 	}
-	if resp.Data["pcf_api_addr"] != e.TestConf.PCFAPIAddr {
-		t.Fatalf("expected %s but received %s", e.TestConf.PCFAPIAddr, resp.Data["pcf_api_addr"])
+	if resp.Data["cf_api_addr"] != e.TestConf.CFAPIAddr {
+		t.Fatalf("expected %s but received %s", e.TestConf.CFAPIAddr, resp.Data["cf_api_addr"])
 	}
-	if resp.Data["pcf_username"] != e.TestConf.PCFUsername {
-		t.Fatalf("expected %s but received %s", e.TestConf.PCFUsername, resp.Data["pcf_username"])
+	if resp.Data["cf_username"] != e.TestConf.CFUsername {
+		t.Fatalf("expected %s but received %s", e.TestConf.CFUsername, resp.Data["cf_username"])
 	}
-	if resp.Data["pcf_password"] != nil {
-		t.Fatalf("expected %s but received %s", "nil", resp.Data["pcf_password"])
+	if resp.Data["cf_password"] != nil {
+		t.Fatalf("expected %s but received %s", "nil", resp.Data["cf_password"])
 	}
 }
 
@@ -201,14 +201,14 @@ func (e *Env) ReadUpdatedConfig(t *testing.T) {
 			t.Fatalf("expected %q but received %q", e.TestConf.IdentityCACertificates[i], caCertRaw)
 		}
 	}
-	if resp.Data["pcf_api_addr"] != e.TestConf.PCFAPIAddr {
-		t.Fatalf("expected %s but received %s", e.TestConf.PCFAPIAddr, resp.Data["pcf_api_addr"])
+	if resp.Data["cf_api_addr"] != e.TestConf.CFAPIAddr {
+		t.Fatalf("expected %s but received %s", e.TestConf.CFAPIAddr, resp.Data["cf_api_addr"])
 	}
-	if resp.Data["pcf_username"] != e.TestConf.PCFUsername {
-		t.Fatalf("expected %s but received %s", e.TestConf.PCFUsername, resp.Data["pcf_username"])
+	if resp.Data["cf_username"] != e.TestConf.CFUsername {
+		t.Fatalf("expected %s but received %s", e.TestConf.CFUsername, resp.Data["cf_username"])
 	}
-	if resp.Data["pcf_password"] != nil {
-		t.Fatalf("expected %s but received %s", "", resp.Data["pcf_password"])
+	if resp.Data["cf_password"] != nil {
+		t.Fatalf("expected %s but received %s", "", resp.Data["cf_password"])
 	}
 }
 
@@ -487,8 +487,8 @@ func (e *Env) Login(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr:%v", resp, err)
 	}
 
-	if resp.Auth.DisplayName != pcf.FoundServiceGUID {
-		t.Fatalf("expected %s but received %s", pcf.FoundServiceGUID, resp.Auth.DisplayName)
+	if resp.Auth.DisplayName != cf.FoundServiceGUID {
+		t.Fatalf("expected %s but received %s", cf.FoundServiceGUID, resp.Auth.DisplayName)
 	}
 	if len(resp.Auth.Policies) != 2 {
 		t.Fatalf("expected 2 policies but received %d", len(resp.Auth.Policies))
@@ -496,23 +496,23 @@ func (e *Env) Login(t *testing.T) {
 	if resp.Auth.InternalData["role"] != "test-role" {
 		t.Fatalf("expected %s but received %s", "test-role", resp.Auth.InternalData["role"])
 	}
-	if resp.Auth.InternalData["instance_id"] != pcf.FoundServiceGUID {
-		t.Fatalf("expected %s but received %s", pcf.FoundServiceGUID, resp.Auth.InternalData["instance_id"])
+	if resp.Auth.InternalData["instance_id"] != cf.FoundServiceGUID {
+		t.Fatalf("expected %s but received %s", cf.FoundServiceGUID, resp.Auth.InternalData["instance_id"])
 	}
-	if resp.Auth.Alias.Metadata["org_id"] != pcf.FoundOrgGUID {
-		t.Fatalf("expected %s but received %s", pcf.FoundOrgGUID, resp.Auth.Alias.Metadata["org_id"])
+	if resp.Auth.Alias.Metadata["org_id"] != cf.FoundOrgGUID {
+		t.Fatalf("expected %s but received %s", cf.FoundOrgGUID, resp.Auth.Alias.Metadata["org_id"])
 	}
-	if resp.Auth.Alias.Metadata["app_id"] != pcf.FoundAppGUID {
-		t.Fatalf("expected %s but received %s", pcf.FoundAppGUID, resp.Auth.Alias.Metadata["app_id"])
+	if resp.Auth.Alias.Metadata["app_id"] != cf.FoundAppGUID {
+		t.Fatalf("expected %s but received %s", cf.FoundAppGUID, resp.Auth.Alias.Metadata["app_id"])
 	}
-	if resp.Auth.Alias.Metadata["space_id"] != pcf.FoundSpaceGUID {
-		t.Fatalf("expected %s but received %s", pcf.FoundSpaceGUID, resp.Auth.Alias.Metadata["space_id"])
+	if resp.Auth.Alias.Metadata["space_id"] != cf.FoundSpaceGUID {
+		t.Fatalf("expected %s but received %s", cf.FoundSpaceGUID, resp.Auth.Alias.Metadata["space_id"])
 	}
 	if resp.Auth.InternalData["ip_addresses"] != nil {
 		t.Fatalf("expected %s but received %s", "", resp.Auth.InternalData["ip_addresses"])
 	}
-	if resp.Auth.Alias.Name != pcf.FoundAppGUID {
-		t.Fatalf("expected %s but received %s", pcf.FoundServiceGUID, resp.Auth.Alias.Name)
+	if resp.Auth.Alias.Name != cf.FoundAppGUID {
+		t.Fatalf("expected %s but received %s", cf.FoundServiceGUID, resp.Auth.Alias.Name)
 	}
 	if !resp.Auth.LeaseOptions.Renewable {
 		t.Fatal("expected lease to be renewable")

--- a/cli.go
+++ b/cli.go
@@ -1,4 +1,4 @@
-package pcf
+package cf
 
 import (
 	"errors"
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/vault-plugin-auth-pcf/signatures"
+	"github.com/hashicorp/vault-plugin-auth-cf/signatures"
 	"github.com/hashicorp/vault/api"
 )
 
@@ -17,7 +17,7 @@ type CLIHandler struct{}
 func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, error) {
 	mount, ok := m["mount"]
 	if !ok {
-		mount = "pcf"
+		mount = "cf"
 	}
 
 	role := m["role"]
@@ -79,33 +79,33 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 
 func (h *CLIHandler) Help() string {
 	help := `
-Usage: vault login -method=pcf [CONFIG K=V...]
+Usage: vault login -method=cf [CONFIG K=V...]
 
-  The PCF auth method allows users to authenticate using PCF's instance identity service.
+  The CF auth method allows users to authenticate using CF's instance identity service.
 
-  The PCF credentials may be specified explicitly via the command line:
+  The CF credentials may be specified explicitly via the command line:
 
-      $ vault login -method=pcf role=...
+      $ vault login -method=cf role=...
 
   This will automatically pull from the CF_INSTANCE_CERT and CF_INSTANCE_KEY values
   in your local environment. If they're not available or you wish to override them, 
   they may also be supplied explicitly:
 
-      $ vault login -method=pcf role=... cf_instance_cert=... cf_instance_key=...
+      $ vault login -method=cf role=... cf_instance_cert=... cf_instance_key=...
 
 Configuration:
 
   cf_instance_cert=<string>
-      Explicit value to use for the path to the PCF instance certificate.
+      Explicit value to use for the path to the CF instance certificate.
 
   cf_instance_key=<string>
-      Explicit value to use for the path to the PCF instance key.
+      Explicit value to use for the path to the CF instance key.
 
   mount=<string>
-      Path where the PCF credential method is mounted. This is usually provided
+      Path where the CF credential method is mounted. This is usually provided
       via the -path flag in the "vault login" command, but it can be specified
       here as well. If specified here, it takes precedence over the value for
-      -path. The default value is "pcf".
+      -path. The default value is "cf".
 
   role=<string>
       Name of the role to request a token against

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,4 +1,4 @@
-package pcf
+package cf
 
 import (
 	"encoding/json"
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/vault-plugin-auth-pcf/models"
-	"github.com/hashicorp/vault-plugin-auth-pcf/signatures"
-	"github.com/hashicorp/vault-plugin-auth-pcf/testing/certificates"
+	"github.com/hashicorp/vault-plugin-auth-cf/models"
+	"github.com/hashicorp/vault-plugin-auth-cf/signatures"
+	"github.com/hashicorp/vault-plugin-auth-cf/testing/certificates"
 	"github.com/hashicorp/vault/api"
 )
 
@@ -89,24 +89,24 @@ func handleLogin(t *testing.T, testCerts *certificates.TestCertificates) func(w 
 			t.Fatal(err)
 		}
 		// Validate the certificate that matches our CA has the expected identity data.
-		pcfCert, err := models.NewPCFCertificateFromx509(cert)
+		cfCert, err := models.NewCFCertificateFromx509(cert)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if pcfCert.IPAddress != testIPAddress {
-			t.Fatalf(`expected %q but received %q`, testIPAddress, pcfCert.IPAddress)
+		if cfCert.IPAddress != testIPAddress {
+			t.Fatalf(`expected %q but received %q`, testIPAddress, cfCert.IPAddress)
 		}
-		if pcfCert.AppID != testAppID {
-			t.Fatalf(`expected %q but received %q`, testAppID, pcfCert.AppID)
+		if cfCert.AppID != testAppID {
+			t.Fatalf(`expected %q but received %q`, testAppID, cfCert.AppID)
 		}
-		if pcfCert.SpaceID != testSpaceID {
-			t.Fatalf(`expected %q but received %q`, testSpaceID, pcfCert.SpaceID)
+		if cfCert.SpaceID != testSpaceID {
+			t.Fatalf(`expected %q but received %q`, testSpaceID, cfCert.SpaceID)
 		}
-		if pcfCert.OrgID != testOrgID {
-			t.Fatalf(`expected %q but received %q`, testOrgID, pcfCert.OrgID)
+		if cfCert.OrgID != testOrgID {
+			t.Fatalf(`expected %q but received %q`, testOrgID, cfCert.OrgID)
 		}
-		if pcfCert.InstanceID != testInstanceID {
-			t.Fatalf(`expected %q but received %q`, testInstanceID, pcfCert.InstanceID)
+		if cfCert.InstanceID != testInstanceID {
+			t.Fatalf(`expected %q but received %q`, testInstanceID, cfCert.InstanceID)
 		}
 		// Success.
 		w.WriteHeader(200)

--- a/cmd/generate-signature/main.go
+++ b/cmd/generate-signature/main.go
@@ -16,7 +16,7 @@ To use it for directly logging into Vault:
 	export CF_INSTANCE_KEY=path/to/instance.key
 	export SIGNING_TIME=$(date -u)
 	export ROLE='test-role'
-	vault write auth/vault-plugin-auth-pcf/login \
+	vault write auth/vault-plugin-auth-cf/login \
 		role=$ROLE \
 		certificate=$CF_INSTANCE_CERT \
 		signing_time=SIGNING_TIME \
@@ -29,8 +29,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/hashicorp/vault-plugin-auth-pcf/signatures"
-	"github.com/hashicorp/vault-plugin-auth-pcf/util"
+	"github.com/hashicorp/vault-plugin-auth-cf/signatures"
+	"github.com/hashicorp/vault-plugin-auth-cf/util"
 )
 
 func main() {

--- a/cmd/make-test-certs/main.go
+++ b/cmd/make-test-certs/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/vault-plugin-auth-pcf/testing/certificates"
+	"github.com/hashicorp/vault-plugin-auth-cf/testing/certificates"
 )
 
 const (

--- a/cmd/mock-cf-server/main.go
+++ b/cmd/mock-cf-server/main.go
@@ -5,15 +5,15 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/hashicorp/vault-plugin-auth-pcf/testing/pcf"
+	"github.com/hashicorp/vault-plugin-auth-cf/testing/cf"
 )
 
 func main() {
-	server := pcf.MockServer(true)
+	server := cf.MockServer(true)
 	defer server.Close()
 	fmt.Println("running at " + server.URL)
-	fmt.Println("username is " + pcf.AuthUsername)
-	fmt.Println("password is " + pcf.AuthPassword)
+	fmt.Println("username is " + cf.AuthUsername)
+	fmt.Println("password is " + cf.AuthPassword)
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	<-c

--- a/cmd/vault-plugin-auth-cf/main.go
+++ b/cmd/vault-plugin-auth-cf/main.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	hclog "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault-plugin-auth-pcf"
+	"github.com/hashicorp/vault-plugin-auth-cf"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/sdk/plugin"
 )
@@ -18,7 +18,7 @@ func main() {
 	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
 
 	if err := plugin.Serve(&plugin.ServeOpts{
-		BackendFactoryFunc: pcf.Factory,
+		BackendFactoryFunc: cf.Factory,
 		TLSProviderFunc:    tlsProviderFunc,
 	}); err != nil {
 		logger := hclog.New(&hclog.LoggerOptions{})

--- a/cmd/verify-certs/main.go
+++ b/cmd/verify-certs/main.go
@@ -15,8 +15,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/hashicorp/vault-plugin-auth-pcf/signatures"
-	"github.com/hashicorp/vault-plugin-auth-pcf/util"
+	"github.com/hashicorp/vault-plugin-auth-cf/signatures"
+	"github.com/hashicorp/vault-plugin-auth-cf/util"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/vault-plugin-auth-pcf
+module github.com/hashicorp/vault-plugin-auth-cf
 
 go 1.12
 

--- a/models/cf_cert.go
+++ b/models/cf_cert.go
@@ -8,14 +8,14 @@ import (
 	"strings"
 )
 
-// NewPCFCertificateFromx509 converts a x509 certificate to a valid, well-formed PCF certificate,
+// NewCFCertificateFromx509 converts a x509 certificate to a valid, well-formed CF certificate,
 // erroring if this isn't possible.
-func NewPCFCertificateFromx509(certificate *x509.Certificate) (*PCFCertificate, error) {
+func NewCFCertificateFromx509(certificate *x509.Certificate) (*CFCertificate, error) {
 	if len(certificate.IPAddresses) != 1 {
-		return nil, fmt.Errorf("valid PCF certs have one IP address, but this has %s", certificate.IPAddresses)
+		return nil, fmt.Errorf("valid CF certs have one IP address, but this has %s", certificate.IPAddresses)
 	}
 
-	pcfCert := &PCFCertificate{
+	cfCert := &CFCertificate{
 		InstanceID: certificate.Subject.CommonName,
 		IPAddress:  certificate.IPAddresses[0].String(),
 	}
@@ -25,17 +25,17 @@ func NewPCFCertificateFromx509(certificate *x509.Certificate) (*PCFCertificate, 
 	apps := 0
 	for _, ou := range certificate.Subject.OrganizationalUnit {
 		if strings.HasPrefix(ou, "space:") {
-			pcfCert.SpaceID = strings.Split(ou, "space:")[1]
+			cfCert.SpaceID = strings.Split(ou, "space:")[1]
 			spaces++
 			continue
 		}
 		if strings.HasPrefix(ou, "organization:") {
-			pcfCert.OrgID = strings.Split(ou, "organization:")[1]
+			cfCert.OrgID = strings.Split(ou, "organization:")[1]
 			orgs++
 			continue
 		}
 		if strings.HasPrefix(ou, "app:") {
-			pcfCert.AppID = strings.Split(ou, "app:")[1]
+			cfCert.AppID = strings.Split(ou, "app:")[1]
 			apps++
 			continue
 		}
@@ -49,35 +49,35 @@ func NewPCFCertificateFromx509(certificate *x509.Certificate) (*PCFCertificate, 
 	if apps > 1 {
 		return nil, fmt.Errorf("expected 1 app but received %d", apps)
 	}
-	if err := pcfCert.validate(); err != nil {
+	if err := cfCert.validate(); err != nil {
 		return nil, err
 	}
-	return pcfCert, nil
+	return cfCert, nil
 }
 
-// NewPCFCertificateFromx509 converts the given fields to a valid, well-formed PCF certificate,
+// NewCFCertificateFromx509 converts the given fields to a valid, well-formed CF certificate,
 // erroring if this isn't possible.
-func NewPCFCertificate(instanceID, orgID, spaceID, appID, ipAddress string) (*PCFCertificate, error) {
-	pcfCert := &PCFCertificate{
+func NewCFCertificate(instanceID, orgID, spaceID, appID, ipAddress string) (*CFCertificate, error) {
+	cfCert := &CFCertificate{
 		InstanceID: instanceID,
 		OrgID:      orgID,
 		SpaceID:    spaceID,
 		AppID:      appID,
 		IPAddress:  ipAddress,
 	}
-	if err := pcfCert.validate(); err != nil {
+	if err := cfCert.validate(); err != nil {
 		return nil, err
 	}
-	return pcfCert, nil
+	return cfCert, nil
 }
 
-// PCFCertificate isn't intended to be instantiated directly; but rather through one of the New
+// CFCertificate isn't intended to be instantiated directly; but rather through one of the New
 // methods, which contain logic validating that the expected fields exist.
-type PCFCertificate struct {
+type CFCertificate struct {
 	InstanceID, OrgID, SpaceID, AppID, IPAddress string
 }
 
-func (c *PCFCertificate) validate() error {
+func (c *CFCertificate) validate() error {
 	if c.InstanceID == "" {
 		return errors.New("no instance ID on given certificate")
 	}

--- a/models/cf_cert_test.go
+++ b/models/cf_cert_test.go
@@ -105,49 +105,49 @@ func TestNewPcfCertificateFromx509(t *testing.T) {
 	if len(certs) != 2 {
 		t.Fatalf("expected 2 certs but received %d", len(certs))
 	}
-	pcfCert, err := NewPCFCertificateFromx509(certs[1])
+	cfCert, err := NewCFCertificateFromx509(certs[1])
 	if err == nil {
 		t.Fatal("expected the second certificate to fail verification")
 	}
-	pcfCert, err = NewPCFCertificateFromx509(certs[0])
+	cfCert, err = NewCFCertificateFromx509(certs[0])
 	if err != nil {
 		t.Fatal("expected the first certificate to be valid")
 	}
-	if pcfCert.InstanceID != "f9c7cd7d-1612-4f57-63a8-f995" {
-		t.Fatalf("expected %s but received %s", "f9c7cd7d-1612-4f57-63a8-f995", pcfCert.InstanceID)
+	if cfCert.InstanceID != "f9c7cd7d-1612-4f57-63a8-f995" {
+		t.Fatalf("expected %s but received %s", "f9c7cd7d-1612-4f57-63a8-f995", cfCert.InstanceID)
 	}
-	if pcfCert.AppID != "2d3e834a-3a25-4591-974c-fa5626d5d0a1" {
-		t.Fatalf("expected %s but received %s", "2d3e834a-3a25-4591-974c-fa5626d5d0a1", pcfCert.AppID)
+	if cfCert.AppID != "2d3e834a-3a25-4591-974c-fa5626d5d0a1" {
+		t.Fatalf("expected %s but received %s", "2d3e834a-3a25-4591-974c-fa5626d5d0a1", cfCert.AppID)
 	}
-	if pcfCert.SpaceID != "3d2eba6b-ef19-44d5-91dd-1975b0db5cc9" {
-		t.Fatalf("expected %s but received %s", "3d2eba6b-ef19-44d5-91dd-1975b0db5cc9", pcfCert.SpaceID)
+	if cfCert.SpaceID != "3d2eba6b-ef19-44d5-91dd-1975b0db5cc9" {
+		t.Fatalf("expected %s but received %s", "3d2eba6b-ef19-44d5-91dd-1975b0db5cc9", cfCert.SpaceID)
 	}
-	if pcfCert.OrgID != "34a878d0-c2f9-4521-ba73-a9f664e82c7b" {
-		t.Fatalf("expected %s but received %s", "34a878d0-c2f9-4521-ba73-a9f664e82c7b", pcfCert.OrgID)
+	if cfCert.OrgID != "34a878d0-c2f9-4521-ba73-a9f664e82c7b" {
+		t.Fatalf("expected %s but received %s", "34a878d0-c2f9-4521-ba73-a9f664e82c7b", cfCert.OrgID)
 	}
-	if pcfCert.IPAddress != "10.255.181.105" {
-		t.Fatalf("expected %s but received %s", "10.255.181.105", pcfCert.IPAddress)
+	if cfCert.IPAddress != "10.255.181.105" {
+		t.Fatalf("expected %s but received %s", "10.255.181.105", cfCert.IPAddress)
 	}
 }
 
-func TestNewPCFCertificate(t *testing.T) {
-	pcfCert, err := NewPCFCertificate("f9c7cd7d-1612-4f57-63a8-f995", "34a878d0-c2f9-4521-ba73-a9f664e82c7b", "3d2eba6b-ef19-44d5-91dd-1975b0db5cc9", "2d3e834a-3a25-4591-974c-fa5626d5d0a1", "10.255.181.105")
+func TestNewCFCertificate(t *testing.T) {
+	cfCert, err := NewCFCertificate("f9c7cd7d-1612-4f57-63a8-f995", "34a878d0-c2f9-4521-ba73-a9f664e82c7b", "3d2eba6b-ef19-44d5-91dd-1975b0db5cc9", "2d3e834a-3a25-4591-974c-fa5626d5d0a1", "10.255.181.105")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if pcfCert.InstanceID != "f9c7cd7d-1612-4f57-63a8-f995" {
-		t.Fatalf("expected %s but received %s", "f9c7cd7d-1612-4f57-63a8-f995", pcfCert.InstanceID)
+	if cfCert.InstanceID != "f9c7cd7d-1612-4f57-63a8-f995" {
+		t.Fatalf("expected %s but received %s", "f9c7cd7d-1612-4f57-63a8-f995", cfCert.InstanceID)
 	}
-	if pcfCert.AppID != "2d3e834a-3a25-4591-974c-fa5626d5d0a1" {
-		t.Fatalf("expected %s but received %s", "2d3e834a-3a25-4591-974c-fa5626d5d0a1", pcfCert.AppID)
+	if cfCert.AppID != "2d3e834a-3a25-4591-974c-fa5626d5d0a1" {
+		t.Fatalf("expected %s but received %s", "2d3e834a-3a25-4591-974c-fa5626d5d0a1", cfCert.AppID)
 	}
-	if pcfCert.SpaceID != "3d2eba6b-ef19-44d5-91dd-1975b0db5cc9" {
-		t.Fatalf("expected %s but received %s", "3d2eba6b-ef19-44d5-91dd-1975b0db5cc9", pcfCert.SpaceID)
+	if cfCert.SpaceID != "3d2eba6b-ef19-44d5-91dd-1975b0db5cc9" {
+		t.Fatalf("expected %s but received %s", "3d2eba6b-ef19-44d5-91dd-1975b0db5cc9", cfCert.SpaceID)
 	}
-	if pcfCert.OrgID != "34a878d0-c2f9-4521-ba73-a9f664e82c7b" {
-		t.Fatalf("expected %s but received %s", "34a878d0-c2f9-4521-ba73-a9f664e82c7b", pcfCert.OrgID)
+	if cfCert.OrgID != "34a878d0-c2f9-4521-ba73-a9f664e82c7b" {
+		t.Fatalf("expected %s but received %s", "34a878d0-c2f9-4521-ba73-a9f664e82c7b", cfCert.OrgID)
 	}
-	if pcfCert.IPAddress != "10.255.181.105" {
-		t.Fatalf("expected %s but received %s", "10.255.181.105", pcfCert.IPAddress)
+	if cfCert.IPAddress != "10.255.181.105" {
+		t.Fatalf("expected %s but received %s", "10.255.181.105", cfCert.IPAddress)
 	}
 }

--- a/models/configuration.go
+++ b/models/configuration.go
@@ -7,17 +7,17 @@ type Configuration struct {
 	// IdentityCACertificates are the CA certificates that should be used for verifying client certificates.
 	IdentityCACertificates []string `json:"identity_ca_certificates"`
 
-	// IdentityCACertificates that, if presented by the PCF API, should be trusted.
-	PCFAPICertificates []string `json:"pcf_api_trusted_certificates"`
+	// IdentityCACertificates that, if presented by the CF API, should be trusted.
+	CFAPICertificates []string `json:"pcf_api_trusted_certificates"`
 
-	// PCFAPIAddr is the address of PCF's API, ex: "https://api.dev.cfdev.sh" or "http://127.0.0.1:33671"
-	PCFAPIAddr string `json:"pcf_api_addr"`
+	// CFAPIAddr is the address of CF's API, ex: "https://api.dev.cfdev.sh" or "http://127.0.0.1:33671"
+	CFAPIAddr string `json:"pcf_api_addr"`
 
-	// The username for the PCF API.
-	PCFUsername string `json:"pcf_username"`
+	// The username for the CF API.
+	CFUsername string `json:"pcf_username"`
 
-	// The password for the PCF API.
-	PCFPassword string `json:"pcf_password"`
+	// The password for the CF API.
+	CFPassword string `json:"pcf_password"`
 
 	// The maximum seconds old a login request's signing time can be.
 	// This is configurable because in some test environments we found as much as 2 hours of clock drift.

--- a/models/configuration.go
+++ b/models/configuration.go
@@ -4,20 +4,33 @@ import "time"
 
 // Configuration is the config as it's reflected in Vault's storage system.
 type Configuration struct {
+	// Version 0 had the following fields:
+	//		PCFAPICertificates []string `json:"pcf_api_trusted_certificates"`
+	//		PCFAPIAddr string `json:"pcf_api_addr"`
+	//		PCFUsername string `json:"pcf_username"`
+	//		PCFPassword string `json:"pcf_password"`
+	// Version 1 is the present version and it adds support for the following fields:
+	//		CFAPICertificates []string `json:"cf_api_trusted_certificates"`
+	//		CFAPIAddr string `json:"cf_api_addr"`
+	//		CFUsername string `json:"cf_username"`
+	//		CFPassword string `json:"cf_password"`
+	// Version 2 is in the future, and we intend to deprecate the fields noted in Version 0.
+	Version int `json:"version"`
+
 	// IdentityCACertificates are the CA certificates that should be used for verifying client certificates.
 	IdentityCACertificates []string `json:"identity_ca_certificates"`
 
 	// IdentityCACertificates that, if presented by the CF API, should be trusted.
-	CFAPICertificates []string `json:"pcf_api_trusted_certificates"`
+	CFAPICertificates []string `json:"cf_api_trusted_certificates"`
 
 	// CFAPIAddr is the address of CF's API, ex: "https://api.dev.cfdev.sh" or "http://127.0.0.1:33671"
-	CFAPIAddr string `json:"pcf_api_addr"`
+	CFAPIAddr string `json:"cf_api_addr"`
 
 	// The username for the CF API.
-	CFUsername string `json:"pcf_username"`
+	CFUsername string `json:"cf_username"`
 
 	// The password for the CF API.
-	CFPassword string `json:"pcf_password"`
+	CFPassword string `json:"cf_password"`
 
 	// The maximum seconds old a login request's signing time can be.
 	// This is configurable because in some test environments we found as much as 2 hours of clock drift.
@@ -26,4 +39,16 @@ type Configuration struct {
 	// The maximum seconds ahead a login request's signing time can be.
 	// This is configurable because in some test environments we found as much as 2 hours of clock drift.
 	LoginMaxSecNotAfter time.Duration `json:"login_max_seconds_not_after"`
+
+	// Deprecated: use CFAPICertificates instead.
+	PCFAPICertificates []string `json:"pcf_api_trusted_certificates"`
+
+	// Deprecated: use CFAPIAddr instead.
+	PCFAPIAddr string `json:"pcf_api_addr"`
+
+	// Deprecated: use CFUsername instead.
+	PCFUsername string `json:"pcf_username"`
+
+	// Deprecated: use CFPassword instead.
+	PCFPassword string `json:"pcf_password"`
 }

--- a/path_config.go
+++ b/path_config.go
@@ -1,4 +1,4 @@
-package pcf
+package cf
 
 import (
 	"context"
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/vault-plugin-auth-pcf/models"
-	"github.com/hashicorp/vault-plugin-auth-pcf/util"
+	"github.com/hashicorp/vault-plugin-auth-cf/models"
+	"github.com/hashicorp/vault-plugin-auth-cf/util"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -19,48 +19,82 @@ func (b *backend) pathConfig() *framework.Path {
 		Pattern: "config",
 		Fields: map[string]*framework.FieldSchema{
 			"identity_ca_certificates": {
-				Required: true,
-				Type:     framework.TypeStringSlice,
+				Type: framework.TypeStringSlice,
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name:  "Identity CA Certificates",
 					Value: `-----BEGIN CERTIFICATE----- ... -----END CERTIFICATE-----`,
 				},
 				Description: "The PEM-format CA certificates that are required to have issued the instance certificates presented for logging in.",
 			},
-			"pcf_api_trusted_certificates": {
+			"cf_api_trusted_certificates": {
 				Type: framework.TypeStringSlice,
 				DisplayAttrs: &framework.DisplayAttributes{
-					Name:  "PCF API Trusted IdentityCACertificates",
+					Name:  "CF API Trusted IdentityCACertificates",
 					Value: `-----BEGIN CERTIFICATE----- ... -----END CERTIFICATE-----`,
 				},
-				Description: "The PEM-format CA certificates that are acceptable for the PCF API to present.",
+				Description: "The PEM-format CA certificates that are acceptable for the CF API to present.",
 			},
-			"pcf_api_addr": {
-				Required: true,
-				Type:     framework.TypeString,
+			"cf_api_addr": {
+				Type: framework.TypeString,
 				DisplayAttrs: &framework.DisplayAttributes{
-					Name:  "PCF API Address",
+					Name:  "CF API Address",
 					Value: "https://api.10.244.0.34.xip.io",
 				},
-				Description: "PCF’s API address.",
+				Description: "CF’s API address.",
 			},
-			"pcf_username": {
-				Required: true,
-				Type:     framework.TypeString,
+			"cf_username": {
+				Type: framework.TypeString,
 				DisplayAttrs: &framework.DisplayAttributes{
-					Name:  "PCF API Username",
+					Name:  "CF API Username",
 					Value: "admin",
 				},
-				Description: "The username for PCF’s API.",
+				Description: "The username for CF’s API.",
 			},
-			"pcf_password": {
-				Required: true,
-				Type:     framework.TypeString,
+			"cf_password": {
+				Type: framework.TypeString,
 				DisplayAttrs: &framework.DisplayAttributes{
-					Name:      "PCF API Password",
+					Name:      "CF API Password",
 					Sensitive: true,
 				},
-				Description: "The password for PCF’s API.",
+				Description: "The password for CF’s API.",
+			},
+			// These fields were in the original release, but are being deprecated because Cloud Foundry is moving
+			// away from using "PCF" to refer to themselves.
+			"pcf_api_trusted_certificates": {
+				Deprecated: true,
+				Type:       framework.TypeStringSlice,
+				DisplayAttrs: &framework.DisplayAttributes{
+					Name:  "CF API Trusted IdentityCACertificates",
+					Value: `-----BEGIN CERTIFICATE----- ... -----END CERTIFICATE-----`,
+				},
+				Description: `Deprecated. Please use "cf_api_trusted_certificates".`,
+			},
+			"pcf_api_addr": {
+				Deprecated: true,
+				Type:       framework.TypeString,
+				DisplayAttrs: &framework.DisplayAttributes{
+					Name:  "CF API Address",
+					Value: "https://api.10.244.0.34.xip.io",
+				},
+				Description: `Deprecated. Please use "cf_api_addr".`,
+			},
+			"pcf_username": {
+				Deprecated: true,
+				Type:       framework.TypeString,
+				DisplayAttrs: &framework.DisplayAttributes{
+					Name:  "CF API Username",
+					Value: "admin",
+				},
+				Description: `Deprecated. Please use "cf_username".`,
+			},
+			"pcf_password": {
+				Deprecated: true,
+				Type:       framework.TypeString,
+				DisplayAttrs: &framework.DisplayAttributes{
+					Name:      "CF API Password",
+					Sensitive: true,
+				},
+				Description: `Deprecated. Please use "cf_password".`,
 			},
 			"login_max_seconds_not_before": {
 				Type: framework.TypeDurationSecond,
@@ -113,19 +147,30 @@ func (b *backend) operationConfigCreateUpdate(ctx context.Context, req *logical.
 		if len(identityCACerts) == 0 {
 			return logical.ErrorResponse("'identity_ca_certificates' is required"), nil
 		}
-		pcfApiAddr := data.Get("pcf_api_addr").(string)
-		if pcfApiAddr == "" {
-			return logical.ErrorResponse("'pcf_api_addr' is required"), nil
+
+		cfApiAddrIfc, ok := data.GetFirst("cf_api_addr", "pcf_api_addr")
+		if !ok {
+			return logical.ErrorResponse("'cf_api_addr' is required"), nil
 		}
-		pcfUsername := data.Get("pcf_username").(string)
-		if pcfUsername == "" {
-			return logical.ErrorResponse("'pcf_username' is required"), nil
+		cfApiAddr := cfApiAddrIfc.(string)
+
+		cfUsernameIfc, ok := data.GetFirst("cf_username", "pcf_username")
+		if !ok {
+			return logical.ErrorResponse("'cf_username' is required"), nil
 		}
-		pcfPassword := data.Get("pcf_password").(string)
-		if pcfPassword == "" {
-			return logical.ErrorResponse("'pcf_password' is required"), nil
+		cfUsername := cfUsernameIfc.(string)
+
+		cfPasswordIfc, ok := data.GetFirst("cf_password", "pcf_password")
+		if !ok {
+			return logical.ErrorResponse("'cf_password' is required"), nil
 		}
-		pcfApiCertificates := data.Get("pcf_api_trusted_certificates").([]string)
+		cfPassword := cfPasswordIfc.(string)
+
+		var cfApiCertificates []string
+		cfApiCertificatesIfc, ok := data.GetFirst("cf_api_trusted_certificates", "pcf_api_trusted_certificates")
+		if ok {
+			cfApiCertificates = cfApiCertificatesIfc.([]string)
+		}
 
 		// Default this to 5 minutes.
 		loginMaxSecNotBefore := 300 * time.Second
@@ -140,10 +185,10 @@ func (b *backend) operationConfigCreateUpdate(ctx context.Context, req *logical.
 		}
 		config = &models.Configuration{
 			IdentityCACertificates: identityCACerts,
-			PCFAPICertificates:     pcfApiCertificates,
-			PCFAPIAddr:             pcfApiAddr,
-			PCFUsername:            pcfUsername,
-			PCFPassword:            pcfPassword,
+			CFAPICertificates:      cfApiCertificates,
+			CFAPIAddr:              cfApiAddr,
+			CFUsername:             cfUsername,
+			CFPassword:             cfPassword,
 			LoginMaxSecNotBefore:   loginMaxSecNotBefore,
 			LoginMaxSecNotAfter:    loginMaxSecNotAfter,
 		}
@@ -152,17 +197,17 @@ func (b *backend) operationConfigCreateUpdate(ctx context.Context, req *logical.
 		if raw, ok := data.GetOk("identity_ca_certificates"); ok {
 			config.IdentityCACertificates = raw.([]string)
 		}
-		if raw, ok := data.GetOk("pcf_api_trusted_certificates"); ok {
-			config.PCFAPICertificates = raw.([]string)
+		if raw, ok := data.GetFirst("cf_api_trusted_certificates", "pcf_api_trusted_certificates"); ok {
+			config.CFAPICertificates = raw.([]string)
 		}
-		if raw, ok := data.GetOk("pcf_api_addr"); ok {
-			config.PCFAPIAddr = raw.(string)
+		if raw, ok := data.GetFirst("cf_api_addr", "pcf_api_addr"); ok {
+			config.CFAPIAddr = raw.(string)
 		}
-		if raw, ok := data.GetOk("pcf_username"); ok {
-			config.PCFUsername = raw.(string)
+		if raw, ok := data.GetFirst("cf_username", "pcf_username"); ok {
+			config.CFUsername = raw.(string)
 		}
-		if raw, ok := data.GetOk("pcf_password"); ok {
-			config.PCFPassword = raw.(string)
+		if raw, ok := data.GetFirst("cf_password", "pcf_password"); ok {
+			config.CFPassword = raw.(string)
 		}
 		if raw, ok := data.GetOk("login_max_seconds_not_before"); ok {
 			config.LoginMaxSecNotBefore = time.Duration(raw.(int)) * time.Second
@@ -174,18 +219,18 @@ func (b *backend) operationConfigCreateUpdate(ctx context.Context, req *logical.
 
 	// To give early and explicit feedback, make sure the config works by executing a test call
 	// and checking that the API version is supported. If they don't have API v2 running, we would
-	// probably expect a timeout of some sort below because it's first called in the NewPCFClient
+	// probably expect a timeout of some sort below because it's first called in the NewCFClient
 	// method.
-	client, err := util.NewPCFClient(config)
+	client, err := util.NewCFClient(config)
 	if err != nil {
-		return nil, fmt.Errorf("unable to establish an initial connection to the PCF API: %s", err)
+		return nil, fmt.Errorf("unable to establish an initial connection to the CF API: %s", err)
 	}
 	info, err := client.GetInfo()
 	if err != nil {
 		return nil, err
 	}
 	if !strings.HasPrefix(info.APIVersion, "2.") {
-		return nil, fmt.Errorf("the PCF auth plugin only supports version 2.X.X of the PCF API")
+		return nil, fmt.Errorf("the CF auth plugin only supports version 2.X.X of the CF API")
 	}
 
 	entry, err := logical.StorageEntryJSON(configStorageKey, config)
@@ -209,9 +254,9 @@ func (b *backend) operationConfigRead(ctx context.Context, req *logical.Request,
 	return &logical.Response{
 		Data: map[string]interface{}{
 			"identity_ca_certificates":     config.IdentityCACertificates,
-			"pcf_api_trusted_certificates": config.PCFAPICertificates,
-			"pcf_api_addr":                 config.PCFAPIAddr,
-			"pcf_username":                 config.PCFUsername,
+			"cf_api_trusted_certificates":  config.CFAPICertificates,
+			"cf_api_addr":                  config.CFAPIAddr,
+			"cf_username":                  config.CFUsername,
 			"login_max_seconds_not_before": config.LoginMaxSecNotBefore / time.Second,
 			"login_max_seconds_not_after":  config.LoginMaxSecNotAfter / time.Second,
 		},
@@ -246,7 +291,7 @@ Provide Vault with the CA certificate used to issue all client certificates.
 `
 
 const pathConfigDesc = `
-When a login is attempted using a PCF client certificate, Vault will verify
+When a login is attempted using a CF client certificate, Vault will verify
 that the client certificate was issued by the CA certificate configured here.
 Only those passing this check will be able to gain authorization.
 `

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -1,4 +1,4 @@
-package pcf
+package cf
 
 import (
 	"net"

--- a/path_roles.go
+++ b/path_roles.go
@@ -1,10 +1,10 @@
-package pcf
+package cf
 
 import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/vault-plugin-auth-pcf/models"
+	"github.com/hashicorp/vault-plugin-auth-cf/models"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/tokenutil"
 	"github.com/hashicorp/vault/sdk/logical"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TOOL=vault-plugin-auth-pcf
+TOOL=vault-plugin-auth-cf
 #
 # This script builds the application from source for multiple platforms.
 set -e

--- a/scripts/generate-test-certs.go
+++ b/scripts/generate-test-certs.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/hashicorp/vault-plugin-auth-pcf/testing/certificates"
+	"github.com/hashicorp/vault-plugin-auth-cf/testing/certificates"
 )
 
 const (

--- a/signatures/version1_test.go
+++ b/signatures/version1_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/vault-plugin-auth-pcf/testing/certificates"
-	"github.com/hashicorp/vault-plugin-auth-pcf/util"
+	"github.com/hashicorp/vault-plugin-auth-cf/testing/certificates"
+	"github.com/hashicorp/vault-plugin-auth-cf/util"
 )
 
 func TestSignVerifyIssuedByFakes(t *testing.T) {

--- a/testing/certificates/generate_test.go
+++ b/testing/certificates/generate_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/vault-plugin-auth-pcf/models"
-	"github.com/hashicorp/vault-plugin-auth-pcf/signatures"
-	"github.com/hashicorp/vault-plugin-auth-pcf/util"
+	"github.com/hashicorp/vault-plugin-auth-cf/models"
+	"github.com/hashicorp/vault-plugin-auth-cf/signatures"
+	"github.com/hashicorp/vault-plugin-auth-cf/util"
 )
 
 func TestGenerate(t *testing.T) {
@@ -48,23 +48,23 @@ func TestGenerate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pcfCert, err := models.NewPCFCertificateFromx509(signingCert)
+	cfCert, err := models.NewCFCertificateFromx509(signingCert)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if pcfCert.InstanceID != "instance-id" {
-		t.Fatalf("expected instance-id but received %q", pcfCert.InstanceID)
+	if cfCert.InstanceID != "instance-id" {
+		t.Fatalf("expected instance-id but received %q", cfCert.InstanceID)
 	}
-	if pcfCert.OrgID != "org-id" {
-		t.Fatalf("expected org-id but received %q", pcfCert.OrgID)
+	if cfCert.OrgID != "org-id" {
+		t.Fatalf("expected org-id but received %q", cfCert.OrgID)
 	}
-	if pcfCert.SpaceID != "space-id" {
-		t.Fatalf("expected space-id but received %q", pcfCert.SpaceID)
+	if cfCert.SpaceID != "space-id" {
+		t.Fatalf("expected space-id but received %q", cfCert.SpaceID)
 	}
-	if pcfCert.AppID != "app-id" {
-		t.Fatalf("expected app-id but received %q", pcfCert.AppID)
+	if cfCert.AppID != "app-id" {
+		t.Fatalf("expected app-id but received %q", cfCert.AppID)
 	}
-	if pcfCert.IPAddress != "10.255.181.105" {
-		t.Fatalf("expected 10.255.181.105 but received %q", pcfCert.IPAddress)
+	if cfCert.IPAddress != "10.255.181.105" {
+		t.Fatalf("expected 10.255.181.105 but received %q", cfCert.IPAddress)
 	}
 }

--- a/testing/cf/mock.go
+++ b/testing/cf/mock.go
@@ -1,4 +1,4 @@
-package pcf
+package cf
 
 import (
 	"fmt"

--- a/util/util.go
+++ b/util/util.go
@@ -31,7 +31,7 @@ func NewCFClient(config *models.Configuration) (*cfclient.Client, error) {
 	}
 	for _, certificate := range config.CFAPICertificates {
 		if ok := rootCAs.AppendCertsFromPEM([]byte(certificate)); !ok {
-			return nil, fmt.Errorf("couldn't append PCF API cert to trust: %s", certificate)
+			return nil, fmt.Errorf("couldn't append CF API cert to trust: %s", certificate)
 		}
 	}
 	tlsConfig := &tls.Config{

--- a/util/util.go
+++ b/util/util.go
@@ -8,18 +8,18 @@ import (
 
 	"github.com/cloudfoundry-community/go-cfclient"
 	"github.com/hashicorp/go-cleanhttp"
-	"github.com/hashicorp/vault-plugin-auth-pcf/models"
+	"github.com/hashicorp/vault-plugin-auth-cf/models"
 )
 
 const BashTimeFormat = "Mon Jan 2 15:04:05 MST 2006"
 
-// NewPCFClient does some work that's needed every time we use the PCF client,
+// NewCFClient does some work that's needed every time we use the PCF client,
 // namely using cleanhttp and configuring it to match the user conf.
-func NewPCFClient(config *models.Configuration) (*cfclient.Client, error) {
+func NewCFClient(config *models.Configuration) (*cfclient.Client, error) {
 	clientConf := &cfclient.Config{
-		ApiAddress: config.PCFAPIAddr,
-		Username:   config.PCFUsername,
-		Password:   config.PCFPassword,
+		ApiAddress: config.CFAPIAddr,
+		Username:   config.CFUsername,
+		Password:   config.CFPassword,
 		HttpClient: cleanhttp.DefaultClient(),
 	}
 	rootCAs, err := x509.SystemCertPool()
@@ -29,7 +29,7 @@ func NewPCFClient(config *models.Configuration) (*cfclient.Client, error) {
 	if rootCAs == nil {
 		rootCAs = x509.NewCertPool()
 	}
-	for _, certificate := range config.PCFAPICertificates {
+	for _, certificate := range config.CFAPICertificates {
 		if ok := rootCAs.AppendCertsFromPEM([]byte(certificate)); !ok {
 			return nil, fmt.Errorf("couldn't append PCF API cert to trust: %s", certificate)
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -13,7 +13,7 @@ import (
 
 const BashTimeFormat = "Mon Jan 2 15:04:05 MST 2006"
 
-// NewCFClient does some work that's needed every time we use the PCF client,
+// NewCFClient does some work that's needed every time we use the CF client,
 // namely using cleanhttp and configuring it to match the user conf.
 func NewCFClient(config *models.Configuration) (*cfclient.Client, error) {
 	clientConf := &cfclient.Config{


### PR DESCRIPTION
This PR replaces references to PCF (Pivotal Cloud Foundry) with CF and Cloud Foundry because after we'd authored this code and added it to Vault, we learned that they no longer prefer to be referred to as "pcf". 

Cloud Foundry has a vast number of API endpoints, so some of our configuration fields were named things like `pcf_api_addr` to provide as much clarity as possible to the user. This means that updating such field names will constitute breaking API changes, so we need to go through a careful deprecation process.

Subsequently, these changes are fully backwards-compatible and takes an approach to field deprecations that matches the approach taken by TokenUtil.