### PR TITLE
Add the ability to vault-auth-plugin-cf to authenticate against CF with client credentials.

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -47,7 +47,7 @@ func TestBackend(t *testing.T) {
 		CFUsername:             cf.AuthUsername,
 		CFPassword:             cf.AuthPassword,
 		CFClientID:             cf.AuthClientID,
-		CFClientSecret:         cf.AuthClientSecrete,
+		CFClientSecret:         cf.AuthClientSecret,
 		LoginMaxSecNotBefore:   5,
 		LoginMaxSecNotAfter:    1,
 	}

--- a/backend_test.go
+++ b/backend_test.go
@@ -46,6 +46,8 @@ func TestBackend(t *testing.T) {
 		CFAPIAddr:              cfServer.URL,
 		CFUsername:             cf.AuthUsername,
 		CFPassword:             cf.AuthPassword,
+		CFClientID:             cf.AuthClientID,
+		CFClientSecret:         cf.AuthClientSecrete,
 		LoginMaxSecNotBefore:   5,
 		LoginMaxSecNotAfter:    1,
 	}
@@ -168,6 +170,8 @@ func (e *Env) CreateConfig(t *testing.T) {
 			"cf_api_addr":                  e.TestConf.CFAPIAddr,
 			"cf_username":                  e.TestConf.CFUsername,
 			"cf_password":                  e.TestConf.CFPassword,
+			"cf_client_id":                 e.TestConf.CFClientID,
+			"cf_client_secret":             e.TestConf.CFClientSecret,
 			"login_max_seconds_not_before": 12,
 			"login_max_seconds_not_after":  13,
 		},
@@ -207,6 +211,12 @@ func (e *Env) ReadConfig(t *testing.T) {
 	}
 	if resp.Data["cf_password"] != nil {
 		t.Fatalf("expected %s but received %s", "nil", resp.Data["cf_password"])
+	}
+	if resp.Data["cf_client_id"] != e.TestConf.CFClientID {
+		t.Fatalf("expected %s but received %s", e.TestConf.CFClientID, resp.Data["cf_client_id"])
+	}
+	if resp.Data["cf_client_secret"] != nil {
+		t.Fatalf("expected %s but received %s", "nil", resp.Data["cf_client_secret"])
 	}
 }
 
@@ -255,6 +265,12 @@ func (e *Env) ReadUpdatedConfig(t *testing.T) {
 	}
 	if resp.Data["cf_password"] != nil {
 		t.Fatalf("expected %s but received %s", "", resp.Data["cf_password"])
+	}
+	if resp.Data["cf_client_id"] != e.TestConf.CFClientID {
+		t.Fatalf("expected %s but received %s", e.TestConf.CFClientID, resp.Data["cf_client_id"])
+	}
+	if resp.Data["cf_client_secret"] != nil {
+		t.Fatalf("expected %s but received %s", "", resp.Data["cf_client_secret"])
 	}
 }
 

--- a/cmd/mock-cf-server/main.go
+++ b/cmd/mock-cf-server/main.go
@@ -15,7 +15,7 @@ func main() {
 	fmt.Println("username is " + cf.AuthUsername)
 	fmt.Println("password is " + cf.AuthPassword)
 	fmt.Println("client id is " + cf.AuthClientID)
-	fmt.Println("client secret is " + cf.AuthClientSecrete)
+	fmt.Println("client secret is " + cf.AuthClientSecret)
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)

--- a/cmd/mock-cf-server/main.go
+++ b/cmd/mock-cf-server/main.go
@@ -14,6 +14,9 @@ func main() {
 	fmt.Println("running at " + server.URL)
 	fmt.Println("username is " + cf.AuthUsername)
 	fmt.Println("password is " + cf.AuthPassword)
+	fmt.Println("client id is " + cf.AuthClientID)
+	fmt.Println("client secret is " + cf.AuthClientSecrete)
+
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	<-c

--- a/models/configuration.go
+++ b/models/configuration.go
@@ -32,6 +32,12 @@ type Configuration struct {
 	// The password for the CF API.
 	CFPassword string `json:"cf_password"`
 
+	// The Client ID for the CF API auth.
+	CFClientID string `json:"cf_client_id"`
+
+	// The Client Secret for the CF API auth.
+	CFClientSecret string `json:"cf_client_secret"`
+
 	// The maximum seconds old a login request's signing time can be.
 	// This is configurable because in some test environments we found as much as 2 hours of clock drift.
 	LoginMaxSecNotBefore time.Duration `json:"login_max_seconds_not_before"`

--- a/testing/cf/mock.go
+++ b/testing/cf/mock.go
@@ -13,6 +13,9 @@ const (
 	AuthUsername = "username"
 	AuthPassword = "password"
 
+	AuthClientID      = "ClientID"
+	AuthClientSecrete = "ClientSecret"
+
 	FoundServiceGUID = "1bf2e7f6-2d1d-41ec-501c-c70"
 	FoundAppGUID     = "2d3e834a-3a25-4591-974c-fa5626d5d0a1"
 	FoundOrgGUID     = "34a878d0-c2f9-4521-ba73-a9f664e82c7bf"

--- a/testing/cf/mock.go
+++ b/testing/cf/mock.go
@@ -14,7 +14,7 @@ const (
 	AuthPassword = "password"
 
 	AuthClientID      = "ClientID"
-	AuthClientSecrete = "ClientSecret"
+	AuthClientSecret = "ClientSecret"
 
 	FoundServiceGUID = "1bf2e7f6-2d1d-41ec-501c-c70"
 	FoundAppGUID     = "2d3e834a-3a25-4591-974c-fa5626d5d0a1"

--- a/util/util.go
+++ b/util/util.go
@@ -17,10 +17,12 @@ const BashTimeFormat = "Mon Jan 2 15:04:05 MST 2006"
 // namely using cleanhttp and configuring it to match the user conf.
 func NewCFClient(config *models.Configuration) (*cfclient.Client, error) {
 	clientConf := &cfclient.Config{
-		ApiAddress: config.CFAPIAddr,
-		Username:   config.CFUsername,
-		Password:   config.CFPassword,
-		HttpClient: cleanhttp.DefaultClient(),
+		ApiAddress:   config.CFAPIAddr,
+		Username:     config.CFUsername,
+		Password:     config.CFPassword,
+		ClientID:     config.CFClientID,
+		ClientSecret: config.CFClientSecret,
+		HttpClient:   cleanhttp.DefaultClient(),
 	}
 	rootCAs, err := x509.SystemCertPool()
 	if err != nil {


### PR DESCRIPTION
# Overview
As it is described in the [issue No. 34](https://github.com/hashicorp/vault-plugin-auth-cf/issues/34) we would like to use client credentials for the authentication of the plugin against Cloud Foundry. 

This change will add another method of authentication that vault-auth-plugin-cf will be able to use. We find this new method better suited for our needs - we are managing the Cloud Foundry platform and will be managing Vault based Secret Management solution.

# Design of Change
The change is using the same method to configure the properties of CF Client library, which can use username/password or client_id/client_secret in order to authenticate with Cloud Foundry instance.

# Related Issues/Pull Requests
[ ] [Issue #34](https://github.com/hashicorp/vault-plugin-auth-cf/issues/34)


# Contributor Checklist
[ ] I've added the section on the use of client credentials to the [README](https://github.com/hashicorp/vault-plugin-auth-cf/blob/master/README.md) file.
[ ] I've followed the instructions in the [README](https://github.com/hashicorp/vault-plugin-auth-cf/blob/master/README.md) file with both username/password and client credentials authentication methods working with the CF Mock Server and a real CF deployment - all works as expected.
[ ] The change is backwards compatible - the end user can decide if they want to use username/password or client credentials authentication method.
