### PR TITLE
Enable mTLS with CF API

### DIFF
--- a/cmd/make-test-certs/main.go
+++ b/cmd/make-test-certs/main.go
@@ -20,7 +20,16 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	mtlsCerts, err := certificates.GenerateMTLS()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	fmt.Printf("path to CA cert to configure in Vault: %s\n", testCerts.PathToCACertificate)
 	fmt.Printf("path to cert to use as CF_INSTANCE_CERT: %s\n", testCerts.PathToInstanceCertificate)
 	fmt.Printf("path to key to use as CF_INSTANCE_KEY: %s\n", testCerts.PathToInstanceKey)
+	fmt.Printf("path to CA cert for mock CF server to trust: %s\n", mtlsCerts.PathToSigningCA)
+	fmt.Printf("path to cert for Vault to use in mTLS: %s\n", mtlsCerts.PathToCertificate)
+	fmt.Printf("path to private key for Vault to use in mTLS: %s\n", mtlsCerts.PathToPrivateKey)
 }

--- a/cmd/mock-cf-server/main.go
+++ b/cmd/mock-cf-server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/hashicorp/vault-plugin-auth-cf/testing/certificates"
 	"os"
 	"os/signal"
 
@@ -9,13 +10,33 @@ import (
 )
 
 func main() {
-	server := cf.MockServer(true)
-	defer server.Close()
-	fmt.Println("running at " + server.URL)
-	fmt.Println("username is " + cf.AuthUsername)
-	fmt.Println("password is " + cf.AuthPassword)
-	fmt.Println("client id is " + cf.AuthClientID)
-	fmt.Println("client secret is " + cf.AuthClientSecret)
+	plainServer := cf.MockServer(true, nil)
+	defer plainServer.Close()
+
+	mtlsCerts, err := certificates.GenerateMTLS()
+	if err != nil {
+		fmt.Printf("could not generate certificates for mTLS: %s", err)
+		return
+	}
+	defer mtlsCerts.Close()
+
+	mtlsServer := cf.MockServer(true, []string{mtlsCerts.SigningCA})
+	defer mtlsServer.Close()
+
+	fmt.Println("plain server running at " + plainServer.URL)
+	fmt.Println("plain server username is " + cf.AuthUsername)
+	fmt.Println("plain server password is " + cf.AuthPassword)
+	fmt.Println("plain server client id is " + cf.AuthClientID)
+	fmt.Println("plain server client secret is " + cf.AuthClientSecret)
+
+	fmt.Println("mtls server is running at " + mtlsServer.URL)
+	fmt.Println("mtls server username is " + cf.AuthUsername)
+	fmt.Println("mtls server password is " + cf.AuthPassword)
+	fmt.Println("mtls server client id is " + cf.AuthClientID)
+	fmt.Println("mtls server client secret is " + cf.AuthClientSecret)
+	fmt.Println("mtls server CA path is " + mtlsCerts.PathToSigningCA)
+	fmt.Println("mtls server will trust certificate at " + mtlsCerts.PathToCertificate)
+	fmt.Println("the key for the trusted certificate is at " + mtlsCerts.PathToPrivateKey)
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)

--- a/models/configuration.go
+++ b/models/configuration.go
@@ -11,6 +11,8 @@ type Configuration struct {
 	//		PCFPassword string `json:"pcf_password"`
 	// Version 1 is the present version and it adds support for the following fields:
 	//		CFAPICertificates []string `json:"cf_api_trusted_certificates"`
+	//		CFMutualTLSCertificate []string `json:"cf_api_mutual_tls_certificate"`
+	//		CFMutualTLSKey *string `json:"cf_api_mutual_tls_key"`
 	//		CFAPIAddr string `json:"cf_api_addr"`
 	//		CFUsername string `json:"cf_username"`
 	//		CFPassword string `json:"cf_password"`
@@ -22,6 +24,12 @@ type Configuration struct {
 
 	// IdentityCACertificates that, if presented by the CF API, should be trusted.
 	CFAPICertificates []string `json:"cf_api_trusted_certificates"`
+
+	// CFMutualTLSCertificate is the certificate that is used to perform mTLS with the CF API.
+	CFMutualTLSCertificate string `json:"cf_api_mutual_tls_certificate"`
+
+	// CFMutualTLSKey is the key that is used to perform mTLS with the CF API.
+	CFMutualTLSKey string `json:"cf_api_mutual_tls_key"`
 
 	// CFAPIAddr is the address of CF's API, ex: "https://api.dev.cfdev.sh" or "http://127.0.0.1:33671"
 	CFAPIAddr string `json:"cf_api_addr"`

--- a/testing/cf/mock.go
+++ b/testing/cf/mock.go
@@ -1,6 +1,8 @@
 package cf
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +15,7 @@ const (
 	AuthUsername = "username"
 	AuthPassword = "password"
 
-	AuthClientID      = "ClientID"
+	AuthClientID     = "ClientID"
 	AuthClientSecret = "ClientSecret"
 
 	FoundServiceGUID = "1bf2e7f6-2d1d-41ec-501c-c70"
@@ -32,7 +34,7 @@ var (
 	logger        = hclog.Default()
 )
 
-func MockServer(loud bool) *httptest.Server {
+func MockServer(loud bool, casToTrust []string) *httptest.Server {
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		if loud {
@@ -90,6 +92,16 @@ func MockServer(loud bool) *httptest.Server {
 		}
 	}))
 	testServerUrl = testServer.URL
+
+	if len(casToTrust) > 0 {
+		clientCACertPool := x509.NewCertPool()
+		for _, ca := range casToTrust {
+			clientCACertPool.AppendCertsFromPEM([]byte(ca))
+		}
+		testServer.TLS = &tls.Config{}
+		testServer.TLS.ClientCAs = clientCACertPool
+	}
+
 	return testServer
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -39,6 +39,20 @@ func NewCFClient(config *models.Configuration) (*cfclient.Client, error) {
 	tlsConfig := &tls.Config{
 		RootCAs: rootCAs,
 	}
+
+	if config.CFMutualTLSCertificate != "" && config.CFMutualTLSKey != "" {
+		cert, err := tls.X509KeyPair(
+			[]byte(config.CFMutualTLSCertificate),
+			[]byte(config.CFMutualTLSKey),
+		)
+
+		if err != nil {
+			return nil, fmt.Errorf("could not parse X509 key pair for mutual TLS")
+		}
+
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
 	clientConf.HttpClient.Transport = &http.Transport{TLSClientConfig: tlsConfig}
 	return cfclient.NewClient(clientConf)
 }


### PR DESCRIPTION
# Overview
Addresses #35: Enables `vault-plugin-auth-cf` to use mutual TLS when communicating with the Cloud Foundry API. Documents how to configure this, and notes this to be careful around. This change should have no impact on the function of the plugin.

# Design of Change
We added 2 new configuration parameters (certificate and key) to the plugin. If they're set, the plugin uses them to form a key & cert pair, which it then uses to perform mutual TLS with the configured Cloud Foundry API.

# Related Issues/Pull Requests
[x] [Issue #35](https://github.com/hashicorp/vault-plugin-auth-cf/issues/35)

# Contributor Checklist
[x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[vault#10356](https://github.com/hashicorp/vault/pull/10356)
[N/A] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible; config parameters are ignored if they're not set
