### PR TITLE
Prepare changelog for v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Unreleased
 
+## v0.15.1
+
+IMPROVEMENTS:
+
+* Updated dependencies:
+   * `github.com/cloudfoundry-community/go-cfclient` v0.0.0-20210823134051-721f0e559306 -> v0.0.0-20220930021109-9c4e6c59ccf1
+   * `github.com/hashicorp/go-hclog` v1.0.0 -> v1.5.0
+   * `github.com/hashicorp/go-sockaddr` v1.0.2 -> v1.0.4
+   * `github.com/hashicorp/go-uuid` v1.0.2 -> v1.0.3
+   * `github.com/hashicorp/vault/api` v1.9.1 -> v1.9.2
+   * `github.com/hashicorp/vault/sdk` v0.9.0 -> v0.9.2
+   * `golang.org/x/net` v0.9.0 -> v0.14.0
+
 ## v0.15.0
 IMPROVEMENTS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## v0.15.1
+## v0.15.1 (September 5th, 2023)
 
 IMPROVEMENTS:
 


### PR DESCRIPTION
## Improvements

* Updated dependencies:
   * `github.com/cloudfoundry-community/go-cfclient` v0.0.0-20210823134051-721f0e559306 -> v0.0.0-20220930021109-9c4e6c59ccf1
   * `github.com/hashicorp/go-hclog` v1.0.0 -> v1.5.0
   * `github.com/hashicorp/go-sockaddr` v1.0.2 -> v1.0.4
   * `github.com/hashicorp/go-uuid` v1.0.2 -> v1.0.3
   * `github.com/hashicorp/vault/api` v1.9.1 -> v1.9.2
   * `github.com/hashicorp/vault/sdk` v0.9.0 -> v0.9.2
   * `golang.org/x/net` v0.9.0 -> v0.14.0