### PR TITLE
prepare changelog for 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.15.2 (February 1st, 2023)
+## v0.16.0 (February 1st, 2023)
 
 IMPROVEMENTS:
 


### PR DESCRIPTION
If this seems a bit redundant, it's because it is.

We want plugin releases (for vault releases?) to be minor versions, so we're changing v0.15.2 to 0.16.0