### PR TITLE
Fix to properly handle plugin init failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TOOL?=vault-plugin-auth-cf
 TEST?=$$(go list ./...)
-TESTARGS  ?= '-test.v'
+TESTARGS  ?= '-test.v -count=1'
 EXTERNAL_TOOLS=
 BUILD_TAGS?=${TOOL}
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
@@ -18,11 +18,11 @@ dev: fmtcheck generate
 
 # testshort runs the quick unit tests and vets the code
 testshort: fmtcheck generate
-	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= go test -short -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=20m -parallel=4
+	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= go test -short -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -timeout=20m -parallel=4
 
 # test runs the unit tests and vets the code
 test: fmtcheck generate
-	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= go test ./... -v -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=20m -parallel=4
+	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= go test ./... -v -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -timeout=20m -parallel=4
 
 testcompile: fmtcheck generate
 	@for pkg in $(TEST) ; do \

--- a/backend.go
+++ b/backend.go
@@ -192,6 +192,11 @@ func (b *backend) newCFClient(_ context.Context, config *models.Configuration) (
 func (b *backend) initialize(ctx context.Context, req *logical.InitializationRequest) error {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
+
+	if req == nil {
+		return fmt.Errorf("initialization request is nil")
+	}
+
 	config, err := getConfig(ctx, req.Storage)
 	if err != nil {
 		b.Logger().Warn("init: failed to get the config from storage", "error", err)

--- a/path_config.go
+++ b/path_config.go
@@ -328,7 +328,7 @@ func (b *backend) operationConfigWrite(ctx context.Context, req *logical.Request
 	}
 
 	if _, err := b.updateCFClient(ctx, config); err != nil {
-		return nil, err
+		return logical.ErrorResponse(err.Error()), nil
 	}
 
 	return nil, nil

--- a/testing/cf/mock.go
+++ b/testing/cf/mock.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-hclog"
 )
@@ -107,6 +108,9 @@ func MockServer(loud bool, casToTrust []string) *httptest.Server {
 		testServer.TLS = &tls.Config{}
 		testServer.TLS.ClientCAs = clientCACertPool
 	}
+
+	// give the server time listen
+	time.Sleep(time.Millisecond * 250)
 
 	return testServer
 }


### PR DESCRIPTION
Previously, whenever the plugin was not cleanly initialized, a login request would result in an init error being returned. This fix ensures that the failed init scenario can be recovered from during a login request.

Other fixes:
-  wrap errors in an error response (no 500 errors)
- login requests now gets a config read lock to ensure a proper login config is used.