### PR TITLE
fix: errcheck for parsing CLI flags

### DIFF
--- a/cmd/vault-plugin-auth-cf/main.go
+++ b/cmd/vault-plugin-auth-cf/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	hclog "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault-plugin-auth-cf"
+	cf "github.com/hashicorp/vault-plugin-auth-cf"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/sdk/plugin"
 )
@@ -15,7 +15,10 @@ import (
 func main() {
 	apiClientMeta := &api.PluginAPIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args[1:])
+
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		fatal(err)
+	}
 
 	tlsConfig := apiClientMeta.GetTLSConfig()
 	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
@@ -26,9 +29,12 @@ func main() {
 		// compatibility with Vault versions that don’t support plugin AutoMTLS
 		TLSProviderFunc: tlsProviderFunc,
 	}); err != nil {
-		logger := hclog.New(&hclog.LoggerOptions{})
-
-		logger.Error("plugin shutting down", "error", err)
-		os.Exit(1)
+		fatal(err)
 	}
+}
+
+func fatal(err error) {
+	logger := hclog.New(&hclog.LoggerOptions{})
+	logger.Error("plugin shutting down", "error", err)
+	os.Exit(1)
 }


### PR DESCRIPTION
# Overview

Add missing error check to `main()` for parsing CLI flags.

# Design of Change

Error check was missing.

# Related Issues/Pull Requests

None

# Contributor Checklist

Fixed in various Vault plugin repositories before such as https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/202 and https://github.com/hashicorp/vault/pull/28692