### PR TITLE
Add timeout to http client

### DIFF
--- a/models/configuration.go
+++ b/models/configuration.go
@@ -54,6 +54,9 @@ type Configuration struct {
 	// The Client Secret for the CF API auth.
 	CFClientSecret string `json:"cf_client_secret"`
 
+	// Timeout for the CF API.
+	CFTimeout time.Duration `json:"cf_timeout"`
+
 	// The maximum seconds old a login request's signing time can be.
 	// This is configurable because in some test environments we found as much as 2 hours of clock drift.
 	LoginMaxSecNotBefore time.Duration `json:"login_max_seconds_not_before"`

--- a/path_config.go
+++ b/path_config.go
@@ -95,6 +95,14 @@ func (b *backend) pathConfig() *framework.Path {
 				},
 				Description: "The client secret for CF’s API.",
 			},
+			"cf_timeout": {
+				Type: framework.TypeDurationSecond,
+				DisplayAttrs: &framework.DisplayAttributes{
+					Name: "CF Timeout",
+				},
+				Description: "The timeout for calls to CF’s API.",
+				Default:     "0s", // 0 means no timeout
+			},
 			// These fields were in the original release, but are being deprecated because Cloud Foundry is moving
 			// away from using "PCF" to refer to themselves.
 			"pcf_api_trusted_certificates": {

--- a/path_login.go
+++ b/path_login.go
@@ -312,6 +312,8 @@ func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, data
 	}
 
 	if err := b.validate(client, role, cfCert, req.Connection.RemoteAddr); err != nil {
+		// taint the client on error so that it will be refreshed on the next login attempt
+		b.cfClientTainted = true
 		return logical.ErrorResponse(err.Error()), nil
 	}
 


### PR DESCRIPTION
# Overview
This PR addresses an issue in the Vault CF Auth Plugin where the HTTP client used to interact with the CF API does not set a timeout, defaulting to 0 (no timeout). This can result in idle connections when there are delays or problems with the CF API server, causing the plugin to hang and exhibit behavior similar to what has been reported by the customer.

To resolve this, the HTTP client is updated to include a configurable timeout, allowing customers to define a value that works best for their environment. This change ensures more robust handling of delays or disruptions in the CF API server and prevents idle connections from causing issues.

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
- [ ] Tests still need to be added to this
- [X] Backwards compatible
