### PR TITLE
prepare for v0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## v0.20.1 (May 1, 2025)
+
+IMPROVEMENTS:
+
+* Bump golang.org/x/net from 0.34.0 to 0.38.0
+
 BUGS:
 
 * Fix a bug where the `cf_timeout` user-provided value was always ignored [GH-104](https://github.com/hashicorp/vault-plugin-auth-cf/pull/104)


### PR DESCRIPTION
This PR updates the changelog to prepare for the 0.20.1 release