### PR TITLE
Revert "VAULT-40025 Add configuration to optionally revert to pre-0.18.0 client behavior"

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -206,10 +206,6 @@ func (b *backend) initialize(ctx context.Context, req *logical.InitializationReq
 	}
 
 	if config != nil {
-		if config.ForceNewClient {
-			//Skip creation of cf client during initialization
-			return nil
-		}
 		if _, err := b.updateCFClient(ctx, config); err != nil {
 			// We only log an error here, since we want the plugin to be able to come up.
 			// Subsequent calls to the plugin will attempt to update the client again.

--- a/backend_test.go
+++ b/backend_test.go
@@ -212,111 +212,6 @@ func TestBackendMTLS(t *testing.T) {
 	t.Run("login", env.Login)
 }
 
-func TestBackendForceNewClient(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	storage := &logical.InmemStorage{}
-
-	testCerts, err := certificates.Generate(cf.FoundServiceGUID, cf.FoundOrgGUID, cf.FoundSpaceGUID, cf.FoundAppGUID, "10.255.181.105")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := testCerts.Close(); err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	invalidCaCertBytes, err := ioutil.ReadFile("testdata/real-certificates/ca.crt")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cfServer := cf.MockServer(false, nil)
-	defer cfServer.Close()
-
-	testConf := &models.Configuration{
-		IdentityCACertificates: []string{testCerts.CACertificate, string(invalidCaCertBytes)},
-		CFAPIAddr:              cfServer.URL,
-		CFUsername:             cf.AuthUsername,
-		CFPassword:             cf.AuthPassword,
-		CFClientID:             cf.AuthClientID,
-		CFClientSecret:         cf.AuthClientSecret,
-		CFTimeout:              30 * time.Second,
-		LoginMaxSecNotBefore:   5,
-		LoginMaxSecNotAfter:    1,
-		ForceNewClient:         true,
-	}
-
-	be, err := Factory(ctx, &logical.BackendConfig{
-		StorageView: storage,
-		Logger:      hclog.Default(),
-		System: &logical.StaticSystemView{
-			DefaultLeaseTTLVal: time.Hour,
-			MaxLeaseTTLVal:     time.Hour,
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	parsedCIDRs, err := parseutil.ParseAddrs([]string{"10.255.181.105/24"})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	env := &Env{
-		Ctx:      ctx,
-		Storage:  storage,
-		Backend:  be,
-		TestConf: testConf,
-		TestRole: &models.RoleEntry{
-			BoundAppIDs:      []string{cf.FoundAppGUID},
-			BoundSpaceIDs:    []string{cf.FoundSpaceGUID},
-			BoundOrgIDs:      []string{cf.FoundOrgGUID},
-			BoundInstanceIDs: []string{cf.FoundServiceGUID},
-			BoundCIDRs:       parsedCIDRs,
-			Policies:         []string{"default", "foo"},
-			TTL:              60,
-			MaxTTL:           2 * 60,
-			Period:           5 * 60,
-		},
-		TestCerts: testCerts,
-	}
-	b := env.Backend.(*backend)
-
-	require.Nil(t, b.cfClient, "expected the cached CF client to be nil")
-	// Exercise all the endpoints with ForceNewClient=true
-	t.Run("create config with force_new_client set", env.CreateConfig)
-	t.Run("read config with force_new_client set", env.ReadConfig)
-	t.Run("create role", env.CreateRole)
-	t.Run("login with force_new_client set", env.Login)
-
-	// Test that login still works with force_new_client=true (creates a fresh CF client each time)
-	t.Run("second login with force_new_client set", env.Login)
-	require.Nil(t, b.cfClient, "expected the cached CF client to be nil")
-
-	//Update force_new_client to false and verify that CF client is cached
-	t.Run("update config with force_new_client unset", func(t *testing.T) {
-		env.UpdateConfigWithForceNewClient(t, false)
-	})
-
-	t.Run("read config with force_new_client unset", env.ReadConfig)
-	t.Run("login with force_new_client unset", env.Login)
-	originalCFClient := b.cfClient
-	require.NotNil(t, originalCFClient, "expected the cached CF client to be not nil")
-	t.Run("login again with force_new_client unset", env.Login)
-	assert.Equal(t, originalCFClient, b.cfClient, "expected the cached CF client to be reused")
-
-	// Test that login works when we update the force_new_client to true again
-	t.Run("update config with force_new_client set", func(t *testing.T) {
-		env.UpdateConfigWithForceNewClient(t, true)
-	})
-
-	t.Run("read config with force_new_client set", env.ReadConfig)
-	t.Run("login with force_new_client set", env.Login)
-}
-
 type Env struct {
 	Ctx     context.Context
 	Storage logical.Storage
@@ -387,7 +282,6 @@ func (e *Env) CreateConfig(t *testing.T) {
 			"cf_timeout":                    e.TestConf.CFTimeout,
 			"login_max_seconds_not_before":  12,
 			"login_max_seconds_not_after":   13,
-			"force_new_client":              e.TestConf.ForceNewClient,
 		},
 	}
 	resp, err := e.Backend.HandleRequest(e.Ctx, req)
@@ -444,9 +338,6 @@ func (e *Env) ReadConfig(t *testing.T) {
 	if resp.Data["cf_timeout"] != e.TestConf.CFTimeout.Seconds() {
 		t.Fatalf("expected %f but received %f", e.TestConf.CFTimeout.Seconds(), resp.Data["cf_timeout"])
 	}
-	if resp.Data["force_new_client"] != e.TestConf.ForceNewClient {
-		t.Fatalf("expected %t but received %v", e.TestConf.ForceNewClient, resp.Data["force_new_client"])
-	}
 }
 
 func (e *Env) UpdateConfig(t *testing.T) {
@@ -456,25 +347,6 @@ func (e *Env) UpdateConfig(t *testing.T) {
 		Storage:   e.Storage,
 		Data: map[string]interface{}{
 			"identity_ca_certificates": []string{"foo1", "foo2"},
-		},
-	}
-	resp, err := e.Backend.HandleRequest(e.Ctx, req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: resp: %#v\nerr:%v", resp, err)
-	}
-	if resp != nil {
-		t.Fatal("expected nil response to represent a 204")
-	}
-}
-
-func (e *Env) UpdateConfigWithForceNewClient(t *testing.T, forceNewClient bool) {
-	e.TestConf.ForceNewClient = forceNewClient
-	req := &logical.Request{
-		Operation: logical.UpdateOperation,
-		Path:      "config",
-		Storage:   e.Storage,
-		Data: map[string]interface{}{
-			"force_new_client": forceNewClient,
 		},
 	}
 	resp, err := e.Backend.HandleRequest(e.Ctx, req)
@@ -1231,24 +1103,6 @@ func Test_backend_initialize(t *testing.T) {
 				wantErr: assert.Error,
 			},
 		},
-		{
-			name:          "force-new-client-true-skips-initialization",
-			wantClientSet: false,
-			cfClientTest: cfClientTest{
-				config:         newConfigWithForceNewClientSet(t, true),
-				withMockServer: true,
-				wantErr:        assert.NoError,
-			},
-		},
-		{
-			name:          "force-new-client-false-initializes-client",
-			wantClientSet: true,
-			cfClientTest: cfClientTest{
-				config:         newConfigWithForceNewClientSet(t, false),
-				withMockServer: true,
-				wantErr:        assert.NoError,
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1311,13 +1165,6 @@ func newConfig(t *testing.T) *models.Configuration {
 		CFUsername: "admin",
 		CFPassword: "password",
 	}
-}
-
-func newConfigWithForceNewClientSet(t *testing.T, forceNewClient bool) *models.Configuration {
-	t.Helper()
-	config := newConfig(t)
-	config.ForceNewClient = forceNewClient
-	return config
 }
 
 func initReq(t *testing.T, ctx context.Context, config *models.Configuration) *logical.InitializationRequest {

--- a/models/configuration.go
+++ b/models/configuration.go
@@ -76,9 +76,6 @@ type Configuration struct {
 
 	// Deprecated: use CFPassword instead.
 	PCFPassword string `json:"pcf_password"`
-
-	// ForceNewClient forces creation of a new CF client for every login request instead of using a cached shared client.
-	ForceNewClient bool `json:"force_new_client"`
 }
 
 // Hash returns a hash of the configuration as a BLAKE2b-256 checksum.

--- a/path_config.go
+++ b/path_config.go
@@ -161,14 +161,6 @@ Set low to reduce the opportunity for replay attacks.`,
 Set low to reduce the opportunity for replay attacks.`,
 				Default: 60,
 			},
-			"force_new_client": {
-				Type: framework.TypeBool,
-				DisplayAttrs: &framework.DisplayAttributes{
-					Name: "Force New Client",
-				},
-				Description: "When set to true, forces creation of a new CF client for every login request instead of using a cached shared client.",
-				Default:     false,
-			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
@@ -284,11 +276,6 @@ func (b *backend) operationConfigWrite(ctx context.Context, req *logical.Request
 			cfTimeout = time.Duration(raw.(int)) * time.Second
 		}
 
-		forceNewClient := false
-		if raw, ok := data.GetOk("force_new_client"); ok {
-			forceNewClient = raw.(bool)
-		}
-
 		config = &models.Configuration{
 			Version:                1,
 			IdentityCACertificates: identityCACerts,
@@ -303,7 +290,6 @@ func (b *backend) operationConfigWrite(ctx context.Context, req *logical.Request
 			LoginMaxSecNotBefore:   loginMaxSecNotBefore,
 			LoginMaxSecNotAfter:    loginMaxSecNotAfter,
 			CFTimeout:              cfTimeout,
-			ForceNewClient:         forceNewClient,
 		}
 	} else {
 		// They're updating a config. Only update the fields that have been sent in the call.
@@ -345,9 +331,6 @@ func (b *backend) operationConfigWrite(ctx context.Context, req *logical.Request
 		if raw, ok := data.GetOk("cf_timeout"); ok {
 			config.CFTimeout = time.Duration(raw.(int)) * time.Second
 		}
-		if raw, ok := data.GetOk("force_new_client"); ok {
-			config.ForceNewClient = raw.(bool)
-		}
 	}
 
 	if err := storeConfig(ctx, req.Storage, config); err != nil {
@@ -362,14 +345,7 @@ func (b *backend) operationConfigWrite(ctx context.Context, req *logical.Request
 		return nil, err
 	}
 
-	if config.ForceNewClient {
-		// To give early and explicit feedback, make sure the config works by executing a test call.
-		// This will create a new client but will not cache it.
-		_, err = b.newCFClient(ctx, config)
-	} else {
-		_, err = b.updateCFClient(ctx, config)
-	}
-	if err != nil {
+	if _, err := b.updateCFClient(ctx, config); err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}
 
@@ -399,7 +375,6 @@ func (b *backend) operationConfigRead(ctx context.Context, req *logical.Request,
 			"cf_client_id":                  config.CFClientID,
 			"login_max_seconds_not_before":  config.LoginMaxSecNotBefore / time.Second,
 			"login_max_seconds_not_after":   config.LoginMaxSecNotAfter / time.Second,
-			"force_new_client":              config.ForceNewClient,
 		},
 	}
 	// Populate any deprecated values and warn about them. These should just be stripped when we go to

--- a/path_login.go
+++ b/path_login.go
@@ -202,13 +202,7 @@ func (b *backend) operationLoginUpdate(ctx context.Context, req *logical.Request
 		b.Logger().Debug(fmt.Sprintf("handling login attempt from %+v", cfCert))
 	}
 
-	var client *cfclient.Client
-	if config.ForceNewClient {
-		//Create a new client for every login request
-		client, err = b.newCFClient(ctx, config)
-	} else {
-		client, err = b.getCFClientOrRefresh(ctx, config)
-	}
+	client, err := b.getCFClientOrRefresh(ctx, config)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}
@@ -312,12 +306,7 @@ func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, data
 	// Reconstruct the certificate and ensure it still meets all constraints.
 	cfCert, err := models.NewCFCertificate(instanceID, orgID, spaceID, appID, ipAddr)
 
-	var client *cfclient.Client
-	if config.ForceNewClient {
-		client, err = b.newCFClient(ctx, config)
-	} else {
-		client, err = b.getCFClientOrRefresh(ctx, config)
-	}
+	client, err := b.getCFClientOrRefresh(ctx, config)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}


### PR DESCRIPTION
Reverts hashicorp/vault-plugin-auth-cf#133