### PR TITLE
VAULT-40025 Add configuration to optionally revert to pre-0.18.0 client behavior

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -206,6 +206,10 @@ func (b *backend) initialize(ctx context.Context, req *logical.InitializationReq
 	}
 
 	if config != nil {
+		if config.ForceNewClient {
+			//Skip creation of cf client during initialization
+			return nil
+		}
 		if _, err := b.updateCFClient(ctx, config); err != nil {
 			// We only log an error here, since we want the plugin to be able to come up.
 			// Subsequent calls to the plugin will attempt to update the client again.

--- a/backend.go
+++ b/backend.go
@@ -46,8 +46,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			b.pathRoles(),
 			b.pathLogin(),
 		},
-		BackendType:    logical.TypeCredential,
-		InitializeFunc: b.initialize,
+		BackendType: logical.TypeCredential,
 	}
 	if err := b.Setup(ctx, conf); err != nil {
 		return nil, err
@@ -191,30 +190,3 @@ func (b *backend) newCFClient(_ context.Context, config *models.Configuration) (
 	return cfclient.NewClient(clientConf)
 }
 
-func (b *backend) initialize(ctx context.Context, req *logical.InitializationRequest) error {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-
-	if req == nil {
-		return fmt.Errorf("initialization request is nil")
-	}
-
-	config, err := getConfig(ctx, req.Storage)
-	if err != nil {
-		b.Logger().Warn("init: failed to get the config from storage", "error", err)
-		return nil
-	}
-
-	if config != nil {
-		if config.ForceNewClient {
-			//Skip creation of cf client during initialization
-			return nil
-		}
-		if _, err := b.updateCFClient(ctx, config); err != nil {
-			// We only log an error here, since we want the plugin to be able to come up.
-			// Subsequent calls to the plugin will attempt to update the client again.
-			b.Logger().Warn("init: failed to update CF client", "error", err)
-		}
-	}
-	return nil
-}

--- a/backend.go
+++ b/backend.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/cloudfoundry-community/go-cfclient"
 	"github.com/hashicorp/go-cleanhttp"
@@ -181,6 +182,11 @@ func (b *backend) newCFClient(_ context.Context, config *models.Configuration) (
 
 	clientConf.HttpClient.Transport = &http.Transport{
 		TLSClientConfig: tlsConfig,
+		// IdleConnTimeout bounds how long idle keep-alive connections linger in
+		// the per-request transport before being closed. Without this, abandoned
+		// transports accumulate open connections until the GC runs.
+		// 90s matches Go's DefaultTransport.
+		IdleConnTimeout: 90 * time.Second,
 	}
 
 	// unfortunately, cfclient.NewClient() has a nasty side effect of reaching out
@@ -189,4 +195,3 @@ func (b *backend) newCFClient(_ context.Context, config *models.Configuration) (
 	// should be a priority.
 	return cfclient.NewClient(clientConf)
 }
-

--- a/backend_test.go
+++ b/backend_test.go
@@ -212,6 +212,111 @@ func TestBackendMTLS(t *testing.T) {
 	t.Run("login", env.Login)
 }
 
+func TestBackendForceNewClient(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	storage := &logical.InmemStorage{}
+
+	testCerts, err := certificates.Generate(cf.FoundServiceGUID, cf.FoundOrgGUID, cf.FoundSpaceGUID, cf.FoundAppGUID, "10.255.181.105")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := testCerts.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	invalidCaCertBytes, err := ioutil.ReadFile("testdata/real-certificates/ca.crt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfServer := cf.MockServer(false, nil)
+	defer cfServer.Close()
+
+	testConf := &models.Configuration{
+		IdentityCACertificates: []string{testCerts.CACertificate, string(invalidCaCertBytes)},
+		CFAPIAddr:              cfServer.URL,
+		CFUsername:             cf.AuthUsername,
+		CFPassword:             cf.AuthPassword,
+		CFClientID:             cf.AuthClientID,
+		CFClientSecret:         cf.AuthClientSecret,
+		CFTimeout:              30 * time.Second,
+		LoginMaxSecNotBefore:   5,
+		LoginMaxSecNotAfter:    1,
+		ForceNewClient:         true,
+	}
+
+	be, err := Factory(ctx, &logical.BackendConfig{
+		StorageView: storage,
+		Logger:      hclog.Default(),
+		System: &logical.StaticSystemView{
+			DefaultLeaseTTLVal: time.Hour,
+			MaxLeaseTTLVal:     time.Hour,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsedCIDRs, err := parseutil.ParseAddrs([]string{"10.255.181.105/24"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	env := &Env{
+		Ctx:      ctx,
+		Storage:  storage,
+		Backend:  be,
+		TestConf: testConf,
+		TestRole: &models.RoleEntry{
+			BoundAppIDs:      []string{cf.FoundAppGUID},
+			BoundSpaceIDs:    []string{cf.FoundSpaceGUID},
+			BoundOrgIDs:      []string{cf.FoundOrgGUID},
+			BoundInstanceIDs: []string{cf.FoundServiceGUID},
+			BoundCIDRs:       parsedCIDRs,
+			Policies:         []string{"default", "foo"},
+			TTL:              60,
+			MaxTTL:           2 * 60,
+			Period:           5 * 60,
+		},
+		TestCerts: testCerts,
+	}
+	b := env.Backend.(*backend)
+
+	require.Nil(t, b.cfClient, "expected the cached CF client to be nil")
+	// Exercise all the endpoints with ForceNewClient=true
+	t.Run("create config with force_new_client set", env.CreateConfig)
+	t.Run("read config with force_new_client set", env.ReadConfig)
+	t.Run("create role", env.CreateRole)
+	t.Run("login with force_new_client set", env.Login)
+
+	// Test that login still works with force_new_client=true (creates a fresh CF client each time)
+	t.Run("second login with force_new_client set", env.Login)
+	require.Nil(t, b.cfClient, "expected the cached CF client to be nil")
+
+	//Update force_new_client to false and verify that CF client is cached
+	t.Run("update config with force_new_client unset", func(t *testing.T) {
+		env.UpdateConfigWithForceNewClient(t, false)
+	})
+
+	t.Run("read config with force_new_client unset", env.ReadConfig)
+	t.Run("login with force_new_client unset", env.Login)
+	originalCFClient := b.cfClient
+	require.NotNil(t, originalCFClient, "expected the cached CF client to be not nil")
+	t.Run("login again with force_new_client unset", env.Login)
+	assert.Equal(t, originalCFClient, b.cfClient, "expected the cached CF client to be reused")
+
+	// Test that login works when we update the force_new_client to true again
+	t.Run("update config with force_new_client set", func(t *testing.T) {
+		env.UpdateConfigWithForceNewClient(t, true)
+	})
+
+	t.Run("read config with force_new_client set", env.ReadConfig)
+	t.Run("login with force_new_client set", env.Login)
+}
+
 type Env struct {
 	Ctx     context.Context
 	Storage logical.Storage
@@ -282,6 +387,7 @@ func (e *Env) CreateConfig(t *testing.T) {
 			"cf_timeout":                    e.TestConf.CFTimeout,
 			"login_max_seconds_not_before":  12,
 			"login_max_seconds_not_after":   13,
+			"force_new_client":              e.TestConf.ForceNewClient,
 		},
 	}
 	resp, err := e.Backend.HandleRequest(e.Ctx, req)
@@ -338,6 +444,9 @@ func (e *Env) ReadConfig(t *testing.T) {
 	if resp.Data["cf_timeout"] != e.TestConf.CFTimeout.Seconds() {
 		t.Fatalf("expected %f but received %f", e.TestConf.CFTimeout.Seconds(), resp.Data["cf_timeout"])
 	}
+	if resp.Data["force_new_client"] != e.TestConf.ForceNewClient {
+		t.Fatalf("expected %t but received %v", e.TestConf.ForceNewClient, resp.Data["force_new_client"])
+	}
 }
 
 func (e *Env) UpdateConfig(t *testing.T) {
@@ -347,6 +456,25 @@ func (e *Env) UpdateConfig(t *testing.T) {
 		Storage:   e.Storage,
 		Data: map[string]interface{}{
 			"identity_ca_certificates": []string{"foo1", "foo2"},
+		},
+	}
+	resp, err := e.Backend.HandleRequest(e.Ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: resp: %#v\nerr:%v", resp, err)
+	}
+	if resp != nil {
+		t.Fatal("expected nil response to represent a 204")
+	}
+}
+
+func (e *Env) UpdateConfigWithForceNewClient(t *testing.T, forceNewClient bool) {
+	e.TestConf.ForceNewClient = forceNewClient
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config",
+		Storage:   e.Storage,
+		Data: map[string]interface{}{
+			"force_new_client": forceNewClient,
 		},
 	}
 	resp, err := e.Backend.HandleRequest(e.Ctx, req)
@@ -1103,6 +1231,24 @@ func Test_backend_initialize(t *testing.T) {
 				wantErr: assert.Error,
 			},
 		},
+		{
+			name:          "force-new-client-true-skips-initialization",
+			wantClientSet: false,
+			cfClientTest: cfClientTest{
+				config:         newConfigWithForceNewClientSet(t, true),
+				withMockServer: true,
+				wantErr:        assert.NoError,
+			},
+		},
+		{
+			name:          "force-new-client-false-initializes-client",
+			wantClientSet: true,
+			cfClientTest: cfClientTest{
+				config:         newConfigWithForceNewClientSet(t, false),
+				withMockServer: true,
+				wantErr:        assert.NoError,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1165,6 +1311,13 @@ func newConfig(t *testing.T) *models.Configuration {
 		CFUsername: "admin",
 		CFPassword: "password",
 	}
+}
+
+func newConfigWithForceNewClientSet(t *testing.T, forceNewClient bool) *models.Configuration {
+	t.Helper()
+	config := newConfig(t)
+	config.ForceNewClient = forceNewClient
+	return config
 }
 
 func initReq(t *testing.T, ctx context.Context, config *models.Configuration) *logical.InitializationRequest {

--- a/backend_test.go
+++ b/backend_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cloudfoundry-community/go-cfclient"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
-	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1190,118 +1189,6 @@ func Test_backend_getCFClientOrRefresh(t *testing.T) {
 	}
 }
 
-func Test_backend_initialize(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-
-	defaultConfig := newConfig(t)
-	defaultInitReq := initReq(t, ctx, defaultConfig)
-
-	type initializeTest struct {
-		cfClientTest
-		req           *logical.InitializationRequest
-		name          string
-		wantClientSet bool
-	}
-
-	tests := []initializeTest{
-		{
-			name:          "valid-server-running",
-			wantClientSet: true,
-			cfClientTest: cfClientTest{
-				config:         newConfig(t),
-				withMockServer: true,
-				wantErr:        assert.NoError,
-			},
-		},
-		{
-			name:          "invalid-server-not-running",
-			wantClientSet: false,
-			req:           defaultInitReq,
-			cfClientTest: cfClientTest{
-				config:         newConfig(t),
-				wantErr:        assert.NoError,
-				withMockServer: false,
-			},
-		},
-		{
-			name: "invalid-nil-init-request",
-			cfClientTest: cfClientTest{
-				wantErr: assert.Error,
-			},
-		},
-		{
-			name:          "force-new-client-true-skips-initialization",
-			wantClientSet: false,
-			cfClientTest: cfClientTest{
-				config:         newConfigWithForceNewClientSet(t, true),
-				withMockServer: true,
-				wantErr:        assert.NoError,
-			},
-		},
-		{
-			name:          "force-new-client-false-initializes-client",
-			wantClientSet: true,
-			cfClientTest: cfClientTest{
-				config:         newConfigWithForceNewClientSet(t, false),
-				withMockServer: true,
-				wantErr:        assert.NoError,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			b := &backend{
-				Backend:        &framework.Backend{},
-				lastConfigHash: tt.lastConfigHash,
-				cfClient:       tt.cfClient,
-			}
-
-			var s *httptest.Server
-			var expectConfigHash [32]byte
-			var err error
-
-			if tt.lastConfigHash != nil && !tt.setConfigHash {
-				expectConfigHash = *tt.lastConfigHash
-			}
-
-			if tt.withMockServer {
-				require.NotNil(t, tt.config, "test %s: config is nil", tt.name)
-				s = cf.MockServer(false, nil)
-				t.Cleanup(func() {
-					if s != nil {
-						s.Close()
-					}
-				})
-
-				tt.config.CFAPIAddr = s.URL
-				expectConfigHash, err = tt.config.Hash()
-				if err != nil {
-					require.FailNow(t, err.Error())
-				}
-
-				if tt.req == nil {
-					tt.req = initReq(t, ctx, tt.config)
-				}
-			}
-
-			err = b.initialize(ctx, tt.req)
-			if !tt.wantErr(t, err, fmt.Sprintf("initialize(%v, %v)", ctx, tt.config)) {
-				return
-			}
-
-			if tt.wantClientSet {
-				assert.NotNilf(t, b.cfClient, "initialize(%v, %v)", ctx, tt.config)
-				assert.NotNilf(t, b.lastConfigHash, "initialize(%v, %v)", ctx, tt.config)
-				assert.Equalf(t, expectConfigHash, *b.lastConfigHash, "initialize(%v, %v)", ctx, tt.config)
-			} else {
-				assert.Nilf(t, b.cfClient, "initialize(%v, %v)", ctx, tt.config)
-				assert.Nilf(t, b.lastConfigHash, "initialize(%v, %v)", ctx, tt.config)
-			}
-		})
-	}
-}
 
 func newConfig(t *testing.T) *models.Configuration {
 	t.Helper()
@@ -1313,20 +1200,3 @@ func newConfig(t *testing.T) *models.Configuration {
 	}
 }
 
-func newConfigWithForceNewClientSet(t *testing.T, forceNewClient bool) *models.Configuration {
-	t.Helper()
-	config := newConfig(t)
-	config.ForceNewClient = forceNewClient
-	return config
-}
-
-func initReq(t *testing.T, ctx context.Context, config *models.Configuration) *logical.InitializationRequest {
-	t.Helper()
-	entry, err := logical.StorageEntryJSON(configStorageKey, config)
-	require.NoError(t, err)
-	storage := &logical.InmemStorage{}
-	require.NoError(t, storage.Put(ctx, entry))
-	return &logical.InitializationRequest{
-		Storage: storage,
-	}
-}

--- a/backend_test.go
+++ b/backend_test.go
@@ -1189,7 +1189,6 @@ func Test_backend_getCFClientOrRefresh(t *testing.T) {
 	}
 }
 
-
 func newConfig(t *testing.T) *models.Configuration {
 	t.Helper()
 	return &models.Configuration{
@@ -1199,4 +1198,3 @@ func newConfig(t *testing.T) *models.Configuration {
 		CFPassword: "password",
 	}
 }
-

--- a/models/configuration.go
+++ b/models/configuration.go
@@ -76,6 +76,9 @@ type Configuration struct {
 
 	// Deprecated: use CFPassword instead.
 	PCFPassword string `json:"pcf_password"`
+
+	// ForceNewClient forces creation of a new CF client for every login request instead of using a cached shared client.
+	ForceNewClient bool `json:"force_new_client"`
 }
 
 // Hash returns a hash of the configuration as a BLAKE2b-256 checksum.

--- a/path_config.go
+++ b/path_config.go
@@ -161,6 +161,14 @@ Set low to reduce the opportunity for replay attacks.`,
 Set low to reduce the opportunity for replay attacks.`,
 				Default: 60,
 			},
+			"force_new_client": {
+				Type: framework.TypeBool,
+				DisplayAttrs: &framework.DisplayAttributes{
+					Name: "Force New Client",
+				},
+				Description: "When set to true, forces creation of a new CF client for every login request instead of using a cached shared client.",
+				Default:     false,
+			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
@@ -276,6 +284,11 @@ func (b *backend) operationConfigWrite(ctx context.Context, req *logical.Request
 			cfTimeout = time.Duration(raw.(int)) * time.Second
 		}
 
+		forceNewClient := false
+		if raw, ok := data.GetOk("force_new_client"); ok {
+			forceNewClient = raw.(bool)
+		}
+
 		config = &models.Configuration{
 			Version:                1,
 			IdentityCACertificates: identityCACerts,
@@ -290,6 +303,7 @@ func (b *backend) operationConfigWrite(ctx context.Context, req *logical.Request
 			LoginMaxSecNotBefore:   loginMaxSecNotBefore,
 			LoginMaxSecNotAfter:    loginMaxSecNotAfter,
 			CFTimeout:              cfTimeout,
+			ForceNewClient:         forceNewClient,
 		}
 	} else {
 		// They're updating a config. Only update the fields that have been sent in the call.
@@ -331,6 +345,9 @@ func (b *backend) operationConfigWrite(ctx context.Context, req *logical.Request
 		if raw, ok := data.GetOk("cf_timeout"); ok {
 			config.CFTimeout = time.Duration(raw.(int)) * time.Second
 		}
+		if raw, ok := data.GetOk("force_new_client"); ok {
+			config.ForceNewClient = raw.(bool)
+		}
 	}
 
 	if err := storeConfig(ctx, req.Storage, config); err != nil {
@@ -345,7 +362,14 @@ func (b *backend) operationConfigWrite(ctx context.Context, req *logical.Request
 		return nil, err
 	}
 
-	if _, err := b.updateCFClient(ctx, config); err != nil {
+	if config.ForceNewClient {
+		// To give early and explicit feedback, make sure the config works by executing a test call.
+		// This will create a new client but will not cache it.
+		_, err = b.newCFClient(ctx, config)
+	} else {
+		_, err = b.updateCFClient(ctx, config)
+	}
+	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}
 
@@ -375,6 +399,7 @@ func (b *backend) operationConfigRead(ctx context.Context, req *logical.Request,
 			"cf_client_id":                  config.CFClientID,
 			"login_max_seconds_not_before":  config.LoginMaxSecNotBefore / time.Second,
 			"login_max_seconds_not_after":   config.LoginMaxSecNotAfter / time.Second,
+			"force_new_client":              config.ForceNewClient,
 		},
 	}
 	// Populate any deprecated values and warn about them. These should just be stripped when we go to

--- a/path_config.go
+++ b/path_config.go
@@ -366,9 +366,9 @@ func (b *backend) operationConfigWrite(ctx context.Context, req *logical.Request
 		// To give early and explicit feedback, make sure the config works by executing a test call.
 		// This will create a new client but will not cache it.
 		_, err = b.newCFClient(ctx, config)
-	
+
 		// Drop any cached client so we don't hold stale connections/state while operating
- 		// in per-request client mode (and so switching back to cached mode forces a refresh).
+		// in per-request client mode (and so switching back to cached mode forces a refresh).
 		b.cfClientMu.Lock()
 		if b.cfClient != nil {
 			if b.cfClient.Config.HttpClient != nil {
@@ -379,7 +379,6 @@ func (b *backend) operationConfigWrite(ctx context.Context, req *logical.Request
 			b.cfClientTainted = false
 		}
 		b.cfClientMu.Unlock()
-
 
 	} else {
 		_, err = b.updateCFClient(ctx, config)

--- a/path_config.go
+++ b/path_config.go
@@ -366,6 +366,21 @@ func (b *backend) operationConfigWrite(ctx context.Context, req *logical.Request
 		// To give early and explicit feedback, make sure the config works by executing a test call.
 		// This will create a new client but will not cache it.
 		_, err = b.newCFClient(ctx, config)
+	
+		// Drop any cached client so we don't hold stale connections/state while operating
+ 		// in per-request client mode (and so switching back to cached mode forces a refresh).
+		b.cfClientMu.Lock()
+		if b.cfClient != nil {
+			if b.cfClient.Config.HttpClient != nil {
+				b.cfClient.Config.HttpClient.CloseIdleConnections()
+			}
+			b.cfClient = nil
+			b.lastConfigHash = nil
+			b.cfClientTainted = false
+		}
+		b.cfClientMu.Unlock()
+
+
 	} else {
 		_, err = b.updateCFClient(ctx, config)
 	}

--- a/path_login.go
+++ b/path_login.go
@@ -202,7 +202,13 @@ func (b *backend) operationLoginUpdate(ctx context.Context, req *logical.Request
 		b.Logger().Debug(fmt.Sprintf("handling login attempt from %+v", cfCert))
 	}
 
-	client, err := b.getCFClientOrRefresh(ctx, config)
+	var client *cfclient.Client
+	if config.ForceNewClient {
+		//Create a new client for every login request
+		client, err = b.newCFClient(ctx, config)
+	} else {
+		client, err = b.getCFClientOrRefresh(ctx, config)
+	}
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}
@@ -306,7 +312,12 @@ func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, data
 	// Reconstruct the certificate and ensure it still meets all constraints.
 	cfCert, err := models.NewCFCertificate(instanceID, orgID, spaceID, appID, ipAddr)
 
-	client, err := b.getCFClientOrRefresh(ctx, config)
+	var client *cfclient.Client
+	if config.ForceNewClient {
+		client, err = b.newCFClient(ctx, config)
+	} else {
+		client, err = b.getCFClientOrRefresh(ctx, config)
+	}
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}

--- a/path_login.go
+++ b/path_login.go
@@ -204,7 +204,7 @@ func (b *backend) operationLoginUpdate(ctx context.Context, req *logical.Request
 
 	var client *cfclient.Client
 	if config.ForceNewClient {
-		//Create a new client for every login request
+		// Create a new client for every login request
 		client, err = b.newCFClient(ctx, config)
 	} else {
 		client, err = b.getCFClientOrRefresh(ctx, config)
@@ -311,6 +311,9 @@ func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, data
 
 	// Reconstruct the certificate and ensure it still meets all constraints.
 	cfCert, err := models.NewCFCertificate(instanceID, orgID, spaceID, appID, ipAddr)
+	if err != nil {
+		return nil, err
+	}
 
 	var client *cfclient.Client
 	if config.ForceNewClient {


### PR DESCRIPTION
# Overview

Who the change affects or is for (stakeholders)?

- Users of the CloudFoundry Auth plugin experiencing errors after upgrading to v0.18.0

What is the change? 

- Added a new configuration option force_new_client to revert to pre-0.18.0 client behavior

Why is the change needed?

- In v0.18.0, the plugin was modified to use a single persistent CF client instead of creating a new one per login
- This change is causing issues due to cached client getting invalidated in certain environments

How does this change affect the user experience (if at all)?

- Provides a workaround for users experiencing CF auth plugin errors

# Design of Change

This solution introduces a force_new_client configuration flag.

- Default (Flag Disabled): The plugin uses the current cached shared client.
- Enabled (Flag Set): The plugin creates a new client for every login request, reverting to the pre-0.18.0 behavior.


# Additional Change 

Removed initialize function / lazy CF client initialization

The backend previously registered an InitializeFunc that eagerly created and cached the CF API client at plugin startup by calling updateCFClient. This meant Vault would attempt to reach the CF API and obtain an OAuth token every time the plugin process started or reloaded.

The initialize function has been removed. The CF client is now created lazily — only when a config write (operationConfigWrite) or a login/renew request actually needs it. This eliminates an unnecessary CF API call at startup of the plugin. The behavior for all login and config operations is unchanged.
