### PR TITLE
Filled in missing OpenAPI metadata for the API endpoints

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -173,20 +173,80 @@ Set low to reduce the opportunity for replay attacks.`,
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.operationConfigWrite,
+				Summary:  "Configure the Cloud Foundry auth method.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationVerb: "configure",
+				},
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
 				},
 			},
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.operationConfigRead,
+				Summary:  "Return the current Cloud Foundry auth method configuration.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "configuration",
+				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"version": {
+								Type:        framework.TypeInt,
+								Description: "Configuration schema version.",
+							},
+							"identity_ca_certificates": {
+								Type:        framework.TypeStringSlice,
+								Description: "PEM-format CA certificates used to verify instance certificates.",
+							},
+							"cf_api_trusted_certificates": {
+								Type:        framework.TypeStringSlice,
+								Description: "PEM-format CA certificates trusted for the CF API.",
+							},
+							"cf_api_mutual_tls_certificate": {
+								Type:        framework.TypeString,
+								Description: "PEM-format certificate used for mutual TLS with the CF API.",
+							},
+							"cf_api_addr": {
+								Type:        framework.TypeString,
+								Description: "Address of the CF API.",
+							},
+							"cf_username": {
+								Type:        framework.TypeString,
+								Description: "Username for the CF API.",
+							},
+							"cf_timeout": {
+								Type:        framework.TypeInt,
+								Description: "Timeout in seconds for CF API calls.",
+							},
+							"cf_client_id": {
+								Type:        framework.TypeString,
+								Description: "Client ID for the CF API.",
+							},
+							"login_max_seconds_not_before": {
+								Type:        framework.TypeInt,
+								Description: "Maximum acceptable age of a signing_time in seconds.",
+							},
+							"login_max_seconds_not_after": {
+								Type:        framework.TypeInt,
+								Description: "Maximum acceptable future offset of a signing_time in seconds.",
+							},
+							"force_new_client": {
+								Type:        framework.TypeBool,
+								Description: "Whether a new CF client is created for every login request.",
+							},
+						},
+					}},
 				},
 			},
 			logical.DeleteOperation: &framework.PathOperation{
 				Callback: b.operationConfigDelete,
+				Summary:  "Delete the Cloud Foundry auth method configuration.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "configuration",
+				},
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
 				},
 			},
 		},
@@ -491,9 +551,7 @@ func deprecationText(newParam, oldParam string) string {
 	return fmt.Sprintf("Use %q instead. If this and %q are both specified, only %q will be used.", newParam, oldParam, newParam)
 }
 
-const pathConfigSyn = `
-Provide Vault with the CA certificate used to issue all client certificates.
-`
+const pathConfigSyn = "Configure the CA certificate used to verify Cloud Foundry instance certificates."
 
 const pathConfigDesc = `
 When a login is attempted using a CF client certificate, Vault will verify

--- a/path_login.go
+++ b/path_login.go
@@ -68,9 +68,38 @@ func (b *backend) pathLogin() *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.operationLoginUpdate,
+				Summary:  "Authenticate a Cloud Foundry instance with Vault.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"lease_duration": {
+								Type:        framework.TypeInt,
+								Description: "Duration of the token lease in seconds.",
+							},
+							"renewable": {
+								Type:        framework.TypeBool,
+								Description: "Whether the token is renewable.",
+							},
+							"metadata": {
+								Type:        framework.TypeMap,
+								Description: "Metadata associated with the token.",
+							},
+							"policies": {
+								Type:        framework.TypeStringSlice,
+								Description: "Policies assigned to the token.",
+							},
+							"display_name": {
+								Type:        framework.TypeString,
+								Description: "Display name of the authenticated entity.",
+							},
+						},
+					}},
+				},
 			},
 			logical.ResolveRoleOperation: &framework.PathOperation{
 				Callback: b.resolveRole,
+				Summary:  "Resolve the role for a Cloud Foundry login request.",
 			},
 		},
 		HelpSynopsis:    pathLoginSyn,
@@ -483,9 +512,7 @@ func getOrErr(fieldName string, from interface{}) (string, error) {
 	}
 }
 
-const pathLoginSyn = `
-Authenticates an entity with Vault.
-`
+const pathLoginSyn = "Authenticate Cloud Foundry entities with Vault."
 
 const pathLoginDesc = `
 Authenticate CF entities using a client certificate issued by the 

--- a/path_roles.go
+++ b/path_roles.go
@@ -26,6 +26,18 @@ func (b *backend) pathListRoles() *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ListOperation: &framework.PathOperation{
 				Callback: b.operationRolesList,
+				Summary:  "List the existing Cloud Foundry auth roles.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"keys": {
+								Type:        framework.TypeStringSlice,
+								Description: "List of role names.",
+							},
+						},
+					}},
+				},
 			},
 		},
 		HelpSynopsis:    pathListRolesHelpSyn,
@@ -126,15 +138,91 @@ an acceptable IP address described by the certificate presented.`,
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.CreateOperation: &framework.PathOperation{
 				Callback: b.operationRolesCreateUpdate,
+				Summary:  "Create a new Cloud Foundry auth role.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.operationRolesCreateUpdate,
+				Summary:  "Update an existing Cloud Foundry auth role.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 			},
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.operationRolesRead,
+				Summary:  "Return the configuration for a named Cloud Foundry auth role.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"bound_application_ids": {
+								Type:        framework.TypeCommaStringSlice,
+								Description: "Bound CF application IDs.",
+							},
+							"bound_space_ids": {
+								Type:        framework.TypeCommaStringSlice,
+								Description: "Bound CF space IDs.",
+							},
+							"bound_organization_ids": {
+								Type:        framework.TypeCommaStringSlice,
+								Description: "Bound CF organization IDs.",
+							},
+							"bound_instance_ids": {
+								Type:        framework.TypeCommaStringSlice,
+								Description: "Bound CF instance IDs.",
+							},
+							"disable_ip_matching": {
+								Type:        framework.TypeBool,
+								Description: "Whether IP address matching is disabled.",
+							},
+							"token_bound_cidrs": {
+								Type:        framework.TypeSlice,
+								Description: "List of token-bound CIDR blocks.",
+							},
+							"token_explicit_max_ttl": {
+								Type:        framework.TypeInt,
+								Description: "Duration in seconds of the explicit maximum TTL.",
+							},
+							"token_max_ttl": {
+								Type:        framework.TypeInt,
+								Description: "Maximum TTL of the token in seconds.",
+							},
+							"token_no_default_policy": {
+								Type:        framework.TypeBool,
+								Description: "Whether the default policy is excluded from the token.",
+							},
+							"token_period": {
+								Type:        framework.TypeInt,
+								Description: "Renewal period of the token in seconds.",
+							},
+							"token_policies": {
+								Type:        framework.TypeSlice,
+								Description: "List of policies on the token.",
+							},
+							"token_type": {
+								Type:        framework.TypeString,
+								Description: "Type of token to generate.",
+							},
+							"token_ttl": {
+								Type:        framework.TypeInt,
+								Description: "Lifetime of the token in seconds.",
+							},
+							"token_num_uses": {
+								Type:        framework.TypeInt,
+								Description: "Maximum number of uses for the token.",
+							},
+						},
+					}},
+				},
 			},
 			logical.DeleteOperation: &framework.PathOperation{
 				Callback: b.operationRolesDelete,
+				Summary:  "Delete a named Cloud Foundry auth role.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 			},
 		},
 		HelpSynopsis:    pathRolesHelpSyn,
@@ -318,9 +406,7 @@ const pathListRolesHelpSyn = "List the existing roles in this backend."
 
 const pathListRolesHelpDesc = "Roles will be listed by the role name."
 
-const pathRolesHelpSyn = `
-Read, write and reference policies and roles that tokens can be made for.
-`
+const pathRolesHelpSyn = "Manage roles used for authenticating Cloud Foundry instances."
 
 const pathRolesHelpDesc = `
 This path allows you to read and write roles that are used to


### PR DESCRIPTION
# Overview
Who the change affects or is for (stakeholders)?
The change affects mainly people who use the Vault's UI. With the added fields, they can better understand the endpoints in the cf auth plugin.

What is the change? 
I added the missing operation summary, path descriptions, and proper typed response schema for the cf auth plugin in path_config.go, path_login.go, and path_roles.go. 

Why is the change needed?
The change is needed because many of the plugins in vault were missing path descriptions, operation summaries, and typed response schemas. Many of the response schemas had a bare 200 Description OK response, which is not sufficient.  

How does this change affect the user experience (if at all)?
When someone uses the Vault UI, they are able to understand the vault plugins better because they have a detailed description of what the endpoint does and  meaningful response schema. With the response schema, they can understand what the endpoint returns.

# Design of Change
How was this change implemented?
I developed an AI skill that automatically adds the HelpSynopsis, Summary, and Response Fields. The Help Synopsis field helps with the path descriptions, and the Help Description and path name are used to come up with the Help Synopsis field. The path name, Operation Prefix, and Operation Suffix are used to come up with the operation summary. For the response schema, the AI skill is able to detect what data types are being added to the response data map, and the skill generates a response schema with those data types. For methods that return a nil, nil, a 204 response code is added.


# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible


